### PR TITLE
Fix prerelease flag syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We're in the prelimiary stages of hooking up the realtime system from nteract/de
 
 ```bash
 # Add to Claude Code
-claude mcp add nteract -- uvx nteract
+claude mcp add nteract -- uvx --prerelease allow nteract
 ```
 
 That's it. Now Claude can execute Python code, create visualizations, and work with your data.
@@ -55,7 +55,7 @@ You can open the same notebook in the [nteract desktop app](https://github.com/n
 ## Installation
 
 ```bash
-uvx --prerelease=allow nteract
+uvx --prerelease allow nteract
 ```
 
 ## Claude Code Setup
@@ -63,7 +63,7 @@ uvx --prerelease=allow nteract
 Add nteract as an MCP server:
 
 ```bash
-claude mcp add nteract -- uvx --prerelease=allow nteract
+claude mcp add nteract -- uvx --prerelease allow nteract
 ```
 
 Or manually add to your Claude configuration:
@@ -73,7 +73,7 @@ Or manually add to your Claude configuration:
   "mcpServers": {
     "nteract": {
       "command": "uvx",
-      "args": ["--prerelease=allow", "nteract"]
+      "args": ["--prerelease", "allow", "nteract"]
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "0.0.3"
+version = "0.0.4"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "nteract"
-version = "0.0.3"
+version = "0.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Fix `--prerelease=allow` → `--prerelease allow` (space-separated syntax)
- Add missing prerelease flag to Quick Start section
- Bump version to 0.0.4

The `=` syntax doesn't work with `uvx`, causing installation failures.