### PR TITLE
Use runtimed Cell.outputs API, remove MCP-level caching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "0.0.5"
+version = "0.0.6"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.26.0",
     "httpx>=0.27.0,<1.0",
-    "runtimed>=0.1.5a1",  # Pin to the prerelease while nteract desktop in preview
+    "runtimed>=0.1.5a202603042356",  # Requires Cell.outputs API from PR #520
 ]
 
 [project.scripts]

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -15,7 +15,6 @@ Requires: pip install nteract
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import json
 import logging
@@ -33,11 +32,6 @@ mcp = FastMCP("nteract")
 # Session state - single active session at a time
 _session: runtimed.AsyncSession | None = None
 _daemon_client: runtimed.DaemonClient | None = None
-
-# Output caching - stores outputs by cell_id after execution
-_cell_outputs: dict[str, list[dict[str, Any]]] = {}
-_cell_status: dict[str, str] = {}  # "idle", "running", "error"
-_pending_executions: dict[str, asyncio.Task[runtimed.ExecutionResult]] = {}
 
 
 def _get_daemon_client() -> runtimed.DaemonClient:
@@ -77,38 +71,15 @@ def _output_to_dict(output: runtimed.Output) -> dict[str, Any]:
     return result
 
 
-async def _check_pending_execution(cell_id: str) -> None:
-    """Check if a pending execution has completed and cache its results."""
-    if cell_id not in _pending_executions:
-        return
-
-    task = _pending_executions[cell_id]
-    if task.done():
-        try:
-            exec_result = task.result()
-            outputs = [_output_to_dict(o) for o in exec_result.outputs]
-            _cell_outputs[cell_id] = outputs
-            _cell_status[cell_id] = "error" if exec_result.error else "idle"
-        except Exception:
-            _cell_status[cell_id] = "error"
-        finally:
-            del _pending_executions[cell_id]
-
-
 def _cell_to_dict(cell: runtimed.Cell) -> dict[str, Any]:
-    """Convert a Cell to a JSON-serializable dict, including cached outputs."""
-    result: dict[str, Any] = {
+    """Convert a Cell to a JSON-serializable dict with outputs from Automerge."""
+    return {
         "id": cell.id,
         "cell_type": cell.cell_type,
         "source": cell.source,
         "execution_count": cell.execution_count,
+        "outputs": [_output_to_dict(o) for o in cell.outputs],
     }
-    # Include cached outputs and status if available
-    if cell.id in _cell_outputs:
-        result["outputs"] = _cell_outputs[cell.id]
-    if cell.id in _cell_status:
-        result["status"] = _cell_status[cell.id]
-    return result
 
 
 def _result_to_dict(result: runtimed.ExecutionResult) -> dict[str, Any]:
@@ -316,31 +287,13 @@ async def create_cell(
     result: dict[str, Any] = {"cell_id": cell_id, "created": True}
 
     if and_run and cell_type == "code":
-        _cell_status[cell_id] = "running"
-        # Create task so it continues even if we timeout waiting
-        # Use ensure_future since runtimed returns a Future, not a coroutine
-        task = asyncio.ensure_future(session.execute_cell(cell_id=cell_id, timeout_secs=60.0))
-        _pending_executions[cell_id] = task
-
-        done, _ = await asyncio.wait({task}, timeout=5.0)
-
-        if done:
-            # Execution completed quickly - cache and return outputs
-            exec_result = task.result()
-            outputs = [_output_to_dict(o) for o in exec_result.outputs]
-            _cell_outputs[cell_id] = outputs
-            _cell_status[cell_id] = "error" if exec_result.error else "idle"
-            del _pending_executions[cell_id]
-            result["status"] = _cell_status[cell_id]
-            result["outputs"] = outputs
-            result["stdout"] = exec_result.stdout
-            result["stderr"] = exec_result.stderr
-            if exec_result.error:
-                result["error"] = _output_to_dict(exec_result.error)
-        else:
-            # Still running - tell agent to poll with get_cell
-            result["status"] = "running"
-            result["message"] = "Execution taking longer than 5s. Use get_cell to poll for results."
+        exec_result = await session.execute_cell(cell_id=cell_id, timeout_secs=60.0)
+        result["status"] = "error" if exec_result.error else "idle"
+        result["outputs"] = [_output_to_dict(o) for o in exec_result.outputs]
+        result["stdout"] = exec_result.stdout
+        result["stderr"] = exec_result.stderr
+        if exec_result.error:
+            result["error"] = _output_to_dict(exec_result.error)
 
     return result
 
@@ -378,9 +331,6 @@ async def get_cell(cell_id: str) -> dict[str, Any]:
         Cell info including id, cell_type, source, execution_count,
         and outputs/status if available.
     """
-    # Check if pending execution has completed
-    await _check_pending_execution(cell_id)
-
     session = await _get_session()
     cell = await session.get_cell(cell_id=cell_id)
     return _cell_to_dict(cell)
@@ -395,10 +345,6 @@ async def get_all_cells() -> list[dict[str, Any]]:
     Returns:
         List of cells with their info, outputs, and status.
     """
-    # Check all pending executions
-    for cell_id in list(_pending_executions.keys()):
-        await _check_pending_execution(cell_id)
-
     session = await _get_session()
     cells = await session.get_cells()
     return [_cell_to_dict(cell) for cell in cells]
@@ -446,16 +392,11 @@ async def execute_cell(
     Returns:
         Execution result including outputs, stdout, stderr, and error info.
     """
-    _cell_status[cell_id] = "running"
     session = await _get_session()
     result = await session.execute_cell(
         cell_id=cell_id,
         timeout_secs=timeout_secs,
     )
-    # Cache outputs
-    outputs = [_output_to_dict(o) for o in result.outputs]
-    _cell_outputs[cell_id] = outputs
-    _cell_status[cell_id] = "error" if result.error else "idle"
     return _result_to_dict(result)
 
 
@@ -480,11 +421,6 @@ async def run_code(
     """
     session = await _get_session()
     result = await session.run(code=code, timeout_secs=timeout_secs)
-    # Cache outputs
-    cell_id = result.cell_id
-    outputs = [_output_to_dict(o) for o in result.outputs]
-    _cell_outputs[cell_id] = outputs
-    _cell_status[cell_id] = "error" if result.error else "idle"
     return _result_to_dict(result)
 
 

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -276,6 +276,7 @@ async def create_cell(
 
     Returns:
         Cell info including id. If and_run=True, includes outputs or status.
+        On execution error, still returns cell_id so you can retry or poll.
     """
     session = await _get_session()
     cell_id = await session.create_cell(
@@ -287,13 +288,18 @@ async def create_cell(
     result: dict[str, Any] = {"cell_id": cell_id, "created": True}
 
     if and_run and cell_type == "code":
-        exec_result = await session.execute_cell(cell_id=cell_id, timeout_secs=60.0)
-        result["status"] = "error" if exec_result.error else "idle"
-        result["outputs"] = [_output_to_dict(o) for o in exec_result.outputs]
-        result["stdout"] = exec_result.stdout
-        result["stderr"] = exec_result.stderr
-        if exec_result.error:
-            result["error"] = _output_to_dict(exec_result.error)
+        try:
+            exec_result = await session.execute_cell(cell_id=cell_id, timeout_secs=60.0)
+            result["status"] = "error" if exec_result.error else "idle"
+            result["outputs"] = [_output_to_dict(o) for o in exec_result.outputs]
+            result["stdout"] = exec_result.stdout
+            result["stderr"] = exec_result.stderr
+            if exec_result.error:
+                result["error"] = _output_to_dict(exec_result.error)
+        except Exception as e:
+            # Execution failed but cell was created - return cell_id so agent can retry
+            result["status"] = "error"
+            result["message"] = f"Execution failed: {e}. Use get_cell to check status."
 
     return result
 
@@ -319,17 +325,17 @@ async def set_cell_source(cell_id: str, source: str) -> dict[str, Any]:
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_cell(cell_id: str) -> dict[str, Any]:
-    """Get a cell by ID, including cached outputs if available.
+    """Get a cell by ID, including outputs if available.
 
-    If a cell execution is pending, checks if it has completed and
-    updates the cache before returning.
+    Outputs are resolved from the Automerge document, so you can see
+    outputs from cells executed by other clients.
 
     Args:
         cell_id: The cell ID.
 
     Returns:
         Cell info including id, cell_type, source, execution_count,
-        and outputs/status if available.
+        and outputs if available.
     """
     session = await _get_session()
     cell = await session.get_cell(cell_id=cell_id)
@@ -338,12 +344,13 @@ async def get_cell(cell_id: str) -> dict[str, Any]:
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_all_cells() -> list[dict[str, Any]]:
-    """Get all cells in the current notebook, including cached outputs.
+    """Get all cells in the current notebook, including outputs.
 
-    Checks for any completed pending executions before returning.
+    Outputs are resolved from the Automerge document, so you can see
+    outputs from cells executed by other clients.
 
     Returns:
-        List of cells with their info, outputs, and status.
+        List of cells with their info and outputs.
     """
     session = await _get_session()
     cells = await session.get_cells()

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "nteract"
-version = "0.0.5"
+version = "0.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -365,7 +365,7 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "mcp", specifier = ">=1.26.0" },
-    { name = "runtimed", specifier = ">=0.1.5a1" },
+    { name = "runtimed", specifier = ">=0.1.5a202603042356" },
 ]
 
 [package.metadata.requires-dev]
@@ -808,12 +808,16 @@ wheels = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.5a202603032110"
+version = "0.1.5a202603042356"
 source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "mcp" },
+]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/c0/08d97e6d72e1fd09ed32bec0103d582fbb20c43083f0b6698218f50efe24/runtimed-0.1.5a202603032110-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d2baa407e80519d361321c6023189abd963e514a41516ee652cc1cab213cd367", size = 1355455, upload-time = "2026-03-03T21:35:52.539Z" },
-    { url = "https://files.pythonhosted.org/packages/73/6e/5ffd21ae4a987a85c884b62876be1a4e5fdf3bd0f752fd30b9284adeb4e7/runtimed-0.1.5a202603032110-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:349b4dd03db98b61b0432c77e505ed5039baaf599dd41d1c988ad0f15ff47863", size = 3856751, upload-time = "2026-03-03T21:35:54.136Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ab/016d7d8afe8a65571bf198a88666e7437f2248d7741740278a865bc9427f/runtimed-0.1.5a202603032110-cp39-abi3-win_amd64.whl", hash = "sha256:829448f9ed5f54e891c411e49c1b15177a0f955161957011e15f21af3c7d014f", size = 1353615, upload-time = "2026-03-03T21:35:55.812Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/b44f6e8013201a749075f06bc8f920e19c696c362da4c08b7343ea6cec84/runtimed-0.1.5a202603042356-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:b3ffb0386b61ce8c481e67e56af082d9895e2952bcf2d566fda9e6b61f0271ca", size = 1356889, upload-time = "2026-03-05T00:27:37.407Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/7a0a50d536593fd3232fbffab743eb2fb34eb31e9b86f21aa3c279d9bd61/runtimed-0.1.5a202603042356-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:93735a24a4212caf1e31f2ab51734f7c54a310f023ae55a34a6cdf8db7cd7027", size = 3856709, upload-time = "2026-03-05T00:27:39.182Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/10/e98e872387ca8624d3c4d10685791872056fe3d2d10a7149c99429b5c344/runtimed-0.1.5a202603042356-cp39-abi3-win_amd64.whl", hash = "sha256:4f7ff2bfa7427de6d162379bedae052e384d5981c660a6a669261b62acfd49ce", size = 1354232, upload-time = "2026-03-05T00:27:40.955Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump runtimed to `>=0.1.5a202603042356` (requires PR #520 from nteract/desktop)
- Use `cell.outputs` directly from Automerge document
- Remove all MCP-level output caching (~60 lines removed)
- Version bump to 0.0.6

## What Changed

The new runtimed version includes `Cell.outputs` populated directly from the Automerge document. This means:

- **Cross-session visibility**: Agents can now see outputs from cells executed by other clients
- **No more caching**: Outputs come from the source of truth (Automerge), not MCP-level cache
- **Simpler code**: Removed `_cell_outputs`, `_cell_status`, `_pending_executions`, and related logic

## Test Plan

- [ ] `uv sync` installs new runtimed
- [ ] `uv run ruff check src/` passes
- [ ] `uv run ty check src/` passes
- [ ] Connect to notebook, execute cell, verify outputs in `get_all_cells()`