### PR TITLE
Add LLM-friendly markdown notebook format

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ Or manually add to your Claude configuration:
 }
 ```
 
+### Using Nightly or Preview Builds
+
+If you're using the nightly build of nteract desktop:
+
+```bash
+claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-nightly/runtimed.sock" uvx --prerelease allow nteract
+```
+
+For the preview build:
+
+```bash
+claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-preview/runtimed.sock" uvx --prerelease allow nteract
+```
+
 ## Available Tools
 
 | Tool | Description |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "0.0.6"
+version = "0.0.7"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -82,6 +82,57 @@ def _cell_to_dict(cell: runtimed.Cell) -> dict[str, Any]:
     }
 
 
+def _output_to_markdown(output: runtimed.Output) -> str:
+    """Convert an Output to markdown format."""
+    if output.output_type == "stream":
+        name = output.name or "stdout"
+        text = output.text or ""
+        return f"```{name}\n{text}\n```"
+
+    elif output.output_type == "execute_result":
+        # Prefer text/plain for LLM readability
+        if output.data:
+            text = output.data.get("text/plain", "")
+            return f"```output\n{text}\n```"
+        return ""
+
+    elif output.output_type == "display_data":
+        # Prefer text/plain for now, images could be added later
+        if output.data:
+            text = output.data.get("text/plain", "")
+            if text:
+                return f"```output\n{text}\n```"
+        return ""
+
+    elif output.output_type == "error":
+        ename = output.ename or "Error"
+        evalue = output.evalue or ""
+        traceback = output.traceback or []
+        tb_text = "\n".join(traceback) if traceback else ""
+        return f"```error\n{ename}: {evalue}\n{tb_text}\n```"
+
+    return ""
+
+
+def _cell_to_markdown(cell: runtimed.Cell) -> str:
+    """Convert a Cell to markdown format."""
+    parts = [f"<!-- Cell ID: {cell.id} -->"]
+
+    if cell.cell_type == "markdown":
+        parts.append(cell.source)
+    elif cell.cell_type == "code":
+        parts.append(f"```python\n{cell.source}\n```")
+        # Add outputs
+        for output in cell.outputs:
+            output_md = _output_to_markdown(output)
+            if output_md:
+                parts.append(output_md)
+    elif cell.cell_type == "raw":
+        parts.append(f"```\n{cell.source}\n```")
+
+    return "\n".join(parts)
+
+
 def _result_to_dict(result: runtimed.ExecutionResult) -> dict[str, Any]:
     """Convert an ExecutionResult to a JSON-serializable dict."""
     return {
@@ -355,6 +406,26 @@ async def get_all_cells() -> list[dict[str, Any]]:
     session = await _get_session()
     cells = await session.get_cells()
     return [_cell_to_dict(cell) for cell in cells]
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_notebook() -> str:
+    """Get the full notebook as LLM-friendly markdown.
+
+    Returns the notebook in a readable markdown format with:
+    - Cell IDs in HTML comments
+    - Markdown cells as plain markdown
+    - Code cells in ```python blocks
+    - Outputs in ```output, ```stdout, ```stderr, or ```error blocks
+
+    This format is easier for LLMs to parse and reason about than JSON.
+
+    Returns:
+        The notebook as a markdown string.
+    """
+    session = await _get_session()
+    cells = await session.get_cells()
+    return "\n\n".join(_cell_to_markdown(cell) for cell in cells)
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -82,26 +82,49 @@ def _cell_to_dict(cell: runtimed.Cell) -> dict[str, Any]:
     }
 
 
+def _fence(content: str, lang: str = "") -> str:
+    """Wrap content in a fenced code block, handling nested backticks."""
+    # Find the longest run of backticks in content
+    max_backticks = 0
+    current_run = 0
+    for char in content:
+        if char == "`":
+            current_run += 1
+            max_backticks = max(max_backticks, current_run)
+        else:
+            current_run = 0
+
+    # Use at least 3 backticks, or more if content has backtick runs
+    fence_len = max(3, max_backticks + 1)
+    fence = "`" * fence_len
+    return f"{fence}{lang}\n{content}\n{fence}"
+
+
 def _output_to_markdown(output: runtimed.Output) -> str:
     """Convert an Output to markdown format."""
     if output.output_type == "stream":
         name = output.name or "stdout"
         text = output.text or ""
-        return f"```{name}\n{text}\n```"
+        return _fence(text, name)
 
     elif output.output_type == "execute_result":
-        # Prefer text/plain for LLM readability
-        if output.data:
-            text = output.data.get("text/plain", "")
-            return f"```output\n{text}\n```"
-        return ""
-
-    elif output.output_type == "display_data":
-        # Prefer text/plain for now, images could be added later
         if output.data:
             text = output.data.get("text/plain", "")
             if text:
-                return f"```output\n{text}\n```"
+                return _fence(text, "output")
+            # Fallback: show available mime types
+            mimes = list(output.data.keys())
+            return _fence(f"[execute_result: {', '.join(mimes)}]", "output")
+        return ""
+
+    elif output.output_type == "display_data":
+        if output.data:
+            text = output.data.get("text/plain", "")
+            if text:
+                return _fence(text, "output")
+            # Fallback: show available mime types
+            mimes = list(output.data.keys())
+            return _fence(f"[display_data: {', '.join(mimes)}]", "output")
         return ""
 
     elif output.output_type == "error":
@@ -109,7 +132,8 @@ def _output_to_markdown(output: runtimed.Output) -> str:
         evalue = output.evalue or ""
         traceback = output.traceback or []
         tb_text = "\n".join(traceback) if traceback else ""
-        return f"```error\n{ename}: {evalue}\n{tb_text}\n```"
+        error_content = f"{ename}: {evalue}\n{tb_text}" if tb_text else f"{ename}: {evalue}"
+        return _fence(error_content, "error")
 
     return ""
 
@@ -121,14 +145,14 @@ def _cell_to_markdown(cell: runtimed.Cell) -> str:
     if cell.cell_type == "markdown":
         parts.append(cell.source)
     elif cell.cell_type == "code":
-        parts.append(f"```python\n{cell.source}\n```")
+        parts.append(_fence(cell.source, "python"))
         # Add outputs
         for output in cell.outputs:
             output_md = _output_to_markdown(output)
             if output_md:
                 parts.append(output_md)
     elif cell.cell_type == "raw":
-        parts.append(f"```\n{cell.source}\n```")
+        parts.append(_fence(cell.source, ""))
 
     return "\n".join(parts)
 


### PR DESCRIPTION
## Summary
- Add `get_notebook()` tool that returns notebooks as readable markdown
- Cell IDs in HTML comments for reference
- Markdown cells rendered as plain markdown
- Code cells in ```python blocks
- Outputs in 

~~~
```output, ```stdout, ```stderr, ```error blocks
~~~