### PR TITLE
Wholesale API rethink: streaming execution with ordered outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,4 @@ jobs:
         run: uv sync --dev
 
       - name: Run tests
-        run: uv run pytest
+        run: uv run pytest --ignore=tests/test_mcp_integration.py

--- a/README.md
+++ b/README.md
@@ -84,10 +84,15 @@ Or manually add to your Claude configuration:
 | Tool | Description |
 |------|-------------|
 | `connect_notebook` | Connect to a notebook (new or existing) |
-| `run_code` | Execute Python code |
-| `create_cell` | Add a cell to the notebook |
-| `execute_cell` | Run a specific cell |
+| `create_cell` | Add a cell to the notebook (use `and_run=True` to execute) |
+| `execute_cell` | Run a specific cell (returns partial results after timeout) |
+| `append_source` | Stream tokens into a cell (ideal for LLM output) |
+| `get_cell` | Get a cell by ID with outputs |
 | `get_all_cells` | View all cells in the notebook |
+| `set_cell_source` | Update a cell's source code |
+| `delete_cell` | Remove a cell from the notebook |
+| `start_kernel` | Start a Python kernel |
+| `get_kernel_status` | Check kernel state |
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.26.0",
     "httpx>=0.27.0,<1.0",
-    "runtimed==0.1.5a202603050550",  # Requires streaming API from PR #528 (pinned until full build)
+    "runtimed>=0.1.5a202603050742",  # Requires streaming API from PR #528
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "0.0.6"
+version = "0.1.0"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.26.0",
     "httpx>=0.27.0,<1.0",
-    "runtimed>=0.1.5a202603042356",  # Requires Cell.outputs API from PR #520
+    "runtimed==0.1.5a202603050550",  # Requires streaming API from PR #528 (pinned until full build)
 ]
 
 [project.scripts]
@@ -26,6 +26,7 @@ packages = ["src/nteract"]
 
 [dependency-groups]
 dev = [
+    "anyio>=4.0",
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "ruff>=0.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "0.1.0"
+version = "0.0.7"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -15,6 +15,7 @@ Requires: pip install nteract
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import logging
@@ -82,16 +83,35 @@ def _cell_to_dict(cell: runtimed.Cell) -> dict[str, Any]:
     }
 
 
-def _result_to_dict(result: runtimed.ExecutionResult) -> dict[str, Any]:
-    """Convert an ExecutionResult to a JSON-serializable dict."""
+def _execution_to_dict(
+    cell_id: str,
+    events: list[Any],  # list[runtimed.ExecutionEvent] - type not exported yet
+    complete: bool,
+) -> dict[str, Any]:
+    """Convert execution events to agent-friendly format.
+
+    Returns ordered outputs preserving interleaving (stdout/display_data/etc).
+    """
+    outputs: list[dict[str, Any]] = []
+    execution_count: int | None = None
+    status = "running"
+
+    for event in events:
+        if event.event_type == "execution_started":
+            execution_count = event.execution_count
+        elif event.event_type == "output":
+            outputs.append(_output_to_dict(event.output))
+        elif event.event_type == "done":
+            status = "idle"
+        elif event.event_type == "error":
+            status = "error"
+
     return {
-        "cell_id": result.cell_id,
-        "success": result.success,
-        "execution_count": result.execution_count,
-        "stdout": result.stdout,
-        "stderr": result.stderr,
-        "outputs": [_output_to_dict(o) for o in result.outputs],
-        "error": _output_to_dict(result.error) if result.error else None,
+        "cell_id": cell_id,
+        "status": status,
+        "execution_count": execution_count,
+        "outputs": outputs,
+        "complete": complete,
     }
 
 
@@ -260,6 +280,7 @@ async def create_cell(
     cell_type: str = "code",
     index: int | None = None,
     and_run: bool = False,
+    timeout_secs: float = 5.0,
 ) -> dict[str, Any]:
     """Create a new cell in the notebook, optionally executing it.
 
@@ -270,13 +291,13 @@ async def create_cell(
         source: Initial source code for the cell.
         cell_type: Cell type - "code", "markdown", or "raw".
         index: Position to insert the cell. None appends at the end.
-        and_run: If True, execute the cell after creating it. For long-running
-            cells, returns after ~5 seconds with status="running". Use get_cell
-            to poll for completion.
+        and_run: If True, execute the cell after creating it.
+        timeout_secs: Max time to wait for execution (default 5s). If execution
+            takes longer, returns partial results with complete=False.
 
     Returns:
-        Cell info including id. If and_run=True, includes outputs or status.
-        On execution error, still returns cell_id so you can retry or poll.
+        Cell info including id. If and_run=True, includes outputs and status.
+        Check 'complete' field to know if execution finished.
     """
     session = await _get_session()
     cell_id = await session.create_cell(
@@ -288,18 +309,8 @@ async def create_cell(
     result: dict[str, Any] = {"cell_id": cell_id, "created": True}
 
     if and_run and cell_type == "code":
-        try:
-            exec_result = await session.execute_cell(cell_id=cell_id, timeout_secs=60.0)
-            result["status"] = "error" if exec_result.error else "idle"
-            result["outputs"] = [_output_to_dict(o) for o in exec_result.outputs]
-            result["stdout"] = exec_result.stdout
-            result["stderr"] = exec_result.stderr
-            if exec_result.error:
-                result["error"] = _output_to_dict(exec_result.error)
-        except Exception as e:
-            # Execution failed but cell was created - return cell_id so agent can retry
-            result["status"] = "error"
-            result["message"] = f"Execution failed: {e}. Use get_cell to check status."
+        exec_result = await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
+        result.update(exec_result)
 
     return result
 
@@ -321,6 +332,26 @@ async def set_cell_source(cell_id: str, source: str) -> dict[str, Any]:
     await session.set_source(cell_id=cell_id, source=source)
 
     return {"cell_id": cell_id, "updated": True}
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+async def append_source(cell_id: str, text: str) -> dict[str, Any]:
+    """Append text to a cell's source code.
+
+    Uses direct CRDT insertion (no diff) - ideal for streaming LLM tokens.
+    Changes sync to all connected clients in real-time.
+
+    Args:
+        cell_id: The cell ID to append to.
+        text: The text to append.
+
+    Returns:
+        Confirmation of append.
+    """
+    session = await _get_session()
+    await session.append_source(cell_id=cell_id, text=text)
+
+    return {"cell_id": cell_id, "appended": True}
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -380,55 +411,50 @@ async def delete_cell(cell_id: str) -> dict[str, Any]:
 # =============================================================================
 
 
+async def _execute_cell_internal(
+    cell_id: str,
+    timeout_secs: float = 5.0,
+) -> dict[str, Any]:
+    """Internal execution with streaming and partial results."""
+    session = await _get_session()
+    events: list[Any] = []  # list[runtimed.ExecutionEvent]
+    complete = False
+
+    async def collect_events() -> None:
+        nonlocal complete
+        async for event in await session.stream_execute(cell_id):
+            events.append(event)
+            if event.event_type in ("done", "error"):
+                complete = True
+                break
+
+    with contextlib.suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(collect_events(), timeout=timeout_secs)
+
+    return _execution_to_dict(cell_id, events, complete)
+
+
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def execute_cell(
     cell_id: str,
-    timeout_secs: float = 60.0,
+    timeout_secs: float = 5.0,
 ) -> dict[str, Any]:
     """Execute a cell by ID.
 
-    The daemon reads the cell's source from the shared document and executes
-    it. This ensures all clients see the same code being executed.
+    Returns partial results after timeout_secs if still running.
+    Check 'complete' field - if False, use get_cell() to poll for more outputs.
 
     If no kernel is running, one will be started automatically.
 
     Args:
         cell_id: The cell ID to execute.
-        timeout_secs: Maximum time to wait for execution (default: 60).
+        timeout_secs: Maximum time to wait for execution (default: 5s).
 
     Returns:
-        Execution result including outputs, stdout, stderr, and error info.
+        Execution result with ordered outputs preserving interleaving.
+        Fields: cell_id, status, execution_count, outputs, complete.
     """
-    session = await _get_session()
-    result = await session.execute_cell(
-        cell_id=cell_id,
-        timeout_secs=timeout_secs,
-    )
-    return _result_to_dict(result)
-
-
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-async def run_code(
-    code: str,
-    timeout_secs: float = 60.0,
-) -> dict[str, Any]:
-    """Execute code in a new cell.
-
-    This is a convenience method that creates a cell, executes it, and returns
-    the result. The cell is persisted in the notebook document.
-
-    If no kernel is running, one will be started automatically.
-
-    Args:
-        code: Python code to execute.
-        timeout_secs: Maximum time to wait for execution (default: 60).
-
-    Returns:
-        Execution result including cell_id, outputs, stdout, stderr, and error.
-    """
-    session = await _get_session()
-    result = await session.run(code=code, timeout_secs=timeout_secs)
-    return _result_to_dict(result)
+    return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
 
 
 # =============================================================================

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -91,19 +91,30 @@ def _execution_to_dict(
     """Convert execution events to agent-friendly format.
 
     Returns ordered outputs preserving interleaving (stdout/display_data/etc).
+    Status reflects execution outcome:
+    - "running": execution in progress
+    - "idle": completed successfully
+    - "error": execution raised an exception or kernel error
     """
     outputs: list[dict[str, Any]] = []
     execution_count: int | None = None
     status = "running"
+    has_error_output = False
 
     for event in events:
         if event.event_type == "execution_started":
             execution_count = event.execution_count
         elif event.event_type == "output":
-            outputs.append(_output_to_dict(event.output))
+            output_dict = _output_to_dict(event.output)
+            outputs.append(output_dict)
+            # Check for error output from user code exceptions (e.g., 1/0)
+            if output_dict.get("output_type") == "error":
+                has_error_output = True
         elif event.event_type == "done":
-            status = "idle"
+            # Set status based on whether any error output was produced
+            status = "error" if has_error_output else "idle"
         elif event.event_type == "error":
+            # Transport/kernel-level error
             status = "error"
 
     return {

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -284,11 +284,13 @@ print('c', flush=True)
         o for o in outputs if o.get("output_type") in ("stream", "display_data")
     ]
 
-    # Verify we have at least 3 outputs in order
-    if len(main_outputs) >= 3:
-        assert main_outputs[0]["output_type"] == "stream"
-        assert main_outputs[1]["output_type"] == "display_data"
-        assert main_outputs[2]["output_type"] == "stream"
+    # Strict assertion: must have exactly 3 outputs in the expected order
+    assert len(main_outputs) == 3, f"Expected 3 outputs, got {len(main_outputs)}: {main_outputs}"
+    assert main_outputs[0]["output_type"] == "stream", "First output should be stream"
+    assert "a" in main_outputs[0].get("text", ""), "First output should contain 'a'"
+    assert main_outputs[1]["output_type"] == "display_data", "Second output should be display_data"
+    assert main_outputs[2]["output_type"] == "stream", "Third output should be stream"
+    assert "c" in main_outputs[2].get("text", ""), "Third output should contain 'c'"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -16,6 +16,8 @@ Skip in CI (requires daemon):
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 from typing import Any
 
@@ -28,28 +30,48 @@ from nteract._mcp_server import mcp
 
 @pytest.fixture
 async def mcp_client():
-    """Create in-memory MCP client connected to our server."""
+    """Create in-memory MCP client connected to our server.
+
+    Uses asyncio for task management to avoid anyio cancel scope
+    issues with pytest-asyncio fixture teardown.
+    """
     # Bidirectional streams: client->server and server->client
     client_send, server_recv = anyio.create_memory_object_stream[Any](0)
     server_send, client_recv = anyio.create_memory_object_stream[Any](0)
 
-    async with anyio.create_task_group() as tg:
-        # Run server in background
-        tg.start_soon(
-            mcp._mcp_server.run,
+    # Start server as asyncio task (not anyio task group)
+    server_task = asyncio.create_task(
+        mcp._mcp_server.run(
             server_recv,
             server_send,
             mcp._mcp_server.create_initialization_options(),
-            True,  # raise_exceptions=True for better test visibility
+            raise_exceptions=True,
         )
+    )
 
-        # Create client session
-        async with ClientSession(client_recv, client_send) as client:
-            await client.initialize()
-            yield client
+    # Give server a moment to start
+    await asyncio.sleep(0.01)
 
-        # Cancel server when done
-        tg.cancel_scope.cancel()
+    # Create client - use manual __aenter__/__aexit__ to control cleanup
+    client = ClientSession(client_recv, client_send)
+    await client.__aenter__()
+
+    try:
+        await client.initialize()
+        yield client
+    finally:
+        # Cancel server first
+        server_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await server_task
+
+        # Close streams to unblock any pending operations
+        await client_send.aclose()
+        await server_send.aclose()
+
+        # Best-effort client cleanup - suppress task context errors
+        with contextlib.suppress(RuntimeError):
+            await client.__aexit__(None, None, None)
 
 
 def _parse_tool_result(result: Any) -> dict[str, Any]:

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -1,0 +1,312 @@
+"""Integration tests for nteract MCP server.
+
+These tests require a running runtimed daemon. They use MCP's in-memory
+transport (anyio memory streams) to test the server without stdio.
+
+Run locally:
+    # Start runtimed daemon first
+    runtimed
+
+    # Run tests
+    uv run pytest tests/test_mcp_integration.py -v
+
+Skip in CI (requires daemon):
+    uv run pytest tests/ -v --ignore=tests/test_mcp_integration.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import anyio
+import pytest
+from mcp import ClientSession
+
+from nteract._mcp_server import mcp
+
+
+@pytest.fixture
+async def mcp_client():
+    """Create in-memory MCP client connected to our server."""
+    # Bidirectional streams: client->server and server->client
+    client_send, server_recv = anyio.create_memory_object_stream[Any](0)
+    server_send, client_recv = anyio.create_memory_object_stream[Any](0)
+
+    async with anyio.create_task_group() as tg:
+        # Run server in background
+        tg.start_soon(
+            mcp._mcp_server.run,
+            server_recv,
+            server_send,
+            mcp._mcp_server.create_initialization_options(),
+            True,  # raise_exceptions=True for better test visibility
+        )
+
+        # Create client session
+        async with ClientSession(client_recv, client_send) as client:
+            await client.initialize()
+            yield client
+
+        # Cancel server when done
+        tg.cancel_scope.cancel()
+
+
+def _parse_tool_result(result: Any) -> dict[str, Any]:
+    """Parse tool result from MCP response."""
+    # Tool results come as a list of content blocks
+    if hasattr(result, "content") and result.content:
+        content = result.content[0]
+        if hasattr(content, "text"):
+            return json.loads(content.text)
+    return {}
+
+
+@pytest.mark.asyncio
+async def test_list_tools(mcp_client: ClientSession):
+    """Verify all expected tools are exposed."""
+    tools = await mcp_client.list_tools()
+    tool_names = {t.name for t in tools.tools}
+
+    # Core tools should be present
+    assert "connect_notebook" in tool_names
+    assert "disconnect_notebook" in tool_names
+    assert "list_notebooks" in tool_names
+    assert "start_kernel" in tool_names
+    assert "shutdown_kernel" in tool_names
+    assert "interrupt_kernel" in tool_names
+    assert "get_kernel_status" in tool_names
+    assert "create_cell" in tool_names
+    assert "set_cell_source" in tool_names
+    assert "append_source" in tool_names
+    assert "get_cell" in tool_names
+    assert "get_all_cells" in tool_names
+    assert "delete_cell" in tool_names
+    assert "execute_cell" in tool_names
+
+    # run_code should be removed
+    assert "run_code" not in tool_names
+
+
+@pytest.mark.asyncio
+async def test_connect_and_create_cell(mcp_client: ClientSession):
+    """Connect to notebook and create a cell."""
+    # Connect
+    result = await mcp_client.call_tool("connect_notebook", {})
+    data = _parse_tool_result(result)
+    assert data["connected"] is True
+    assert "notebook_id" in data
+
+    # Create cell
+    result = await mcp_client.call_tool(
+        "create_cell",
+        {"source": "print('hello')", "cell_type": "code"},
+    )
+    data = _parse_tool_result(result)
+    assert data["created"] is True
+    assert "cell_id" in data
+
+    # Get cell
+    cell_id = data["cell_id"]
+    result = await mcp_client.call_tool("get_cell", {"cell_id": cell_id})
+    data = _parse_tool_result(result)
+    assert data["source"] == "print('hello')"
+    assert data["cell_type"] == "code"
+
+
+@pytest.mark.asyncio
+async def test_append_source(mcp_client: ClientSession):
+    """Test streaming tokens into a cell."""
+    # Connect
+    await mcp_client.call_tool("connect_notebook", {})
+
+    # Create empty cell
+    result = await mcp_client.call_tool("create_cell", {"source": ""})
+    data = _parse_tool_result(result)
+    cell_id = data["cell_id"]
+
+    # Stream tokens
+    tokens = ["print", "(", "'hello", " ", "world", "'", ")"]
+    for token in tokens:
+        result = await mcp_client.call_tool(
+            "append_source",
+            {"cell_id": cell_id, "text": token},
+        )
+        data = _parse_tool_result(result)
+        assert data["appended"] is True
+
+    # Verify final source
+    result = await mcp_client.call_tool("get_cell", {"cell_id": cell_id})
+    data = _parse_tool_result(result)
+    assert data["source"] == "print('hello world')"
+
+
+@pytest.mark.asyncio
+async def test_execute_cell_basic(mcp_client: ClientSession):
+    """Test basic cell execution."""
+    # Connect and start kernel
+    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("start_kernel", {})
+
+    # Create and execute cell
+    result = await mcp_client.call_tool(
+        "create_cell",
+        {
+            "source": "print('hello from kernel')",
+            "and_run": True,
+            "timeout_secs": 30.0,  # Give enough time for kernel warmup
+        },
+    )
+    data = _parse_tool_result(result)
+
+    assert data["created"] is True
+    assert "cell_id" in data
+    # Should have status and outputs
+    assert "status" in data
+    assert "outputs" in data
+
+
+@pytest.mark.asyncio
+async def test_execute_cell_partial_results(mcp_client: ClientSession):
+    """Execute long-running code, verify partial results returned."""
+    # Connect and start kernel
+    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("start_kernel", {})
+
+    # Create cell with slow code - print immediately, then sleep
+    result = await mcp_client.call_tool(
+        "create_cell",
+        {
+            "source": "import time; print('start'); time.sleep(10); print('done')",
+            "and_run": True,
+            "timeout_secs": 2.0,  # Short timeout to test partial results
+        },
+    )
+    data = _parse_tool_result(result)
+
+    # Should have partial output and complete=False
+    assert data.get("complete") is False
+    assert data.get("status") == "running"
+    # Should have at least the "start" output
+    outputs = data.get("outputs", [])
+    output_text = "".join(
+        o.get("text", "") for o in outputs if o.get("output_type") == "stream"
+    )
+    assert "start" in output_text
+
+
+@pytest.mark.asyncio
+async def test_poll_for_outputs(mcp_client: ClientSession):
+    """Create cell, execute, poll get_cell for updated outputs."""
+    # Connect and start kernel
+    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("start_kernel", {})
+
+    # Create cell with short delay
+    result = await mcp_client.call_tool(
+        "create_cell",
+        {
+            "source": "import time; time.sleep(1); print('done')",
+            "and_run": True,
+            "timeout_secs": 0.5,  # Return before completion
+        },
+    )
+    data = _parse_tool_result(result)
+    cell_id = data["cell_id"]
+
+    # Should be incomplete
+    assert data.get("complete") is False
+
+    # Wait and poll
+    await anyio.sleep(2)
+    result = await mcp_client.call_tool("get_cell", {"cell_id": cell_id})
+    data = _parse_tool_result(result)
+
+    # Should now have the output
+    outputs = data.get("outputs", [])
+    output_text = "".join(
+        o.get("text", "") for o in outputs if o.get("output_type") == "stream"
+    )
+    assert "done" in output_text
+
+
+@pytest.mark.asyncio
+async def test_output_ordering(mcp_client: ClientSession):
+    """Verify interleaved outputs maintain order."""
+    # Connect and start kernel
+    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("start_kernel", {})
+
+    # Code that produces interleaved outputs
+    code = """
+import sys
+print('a', flush=True)
+from IPython.display import display
+display('b')
+print('c', flush=True)
+"""
+    result = await mcp_client.call_tool(
+        "create_cell",
+        {
+            "source": code,
+            "and_run": True,
+            "timeout_secs": 30.0,
+        },
+    )
+    data = _parse_tool_result(result)
+
+    outputs = data.get("outputs", [])
+    # Should be: stream(a), display_data(b), stream(c) in order
+    # Filter to just the main output types
+    main_outputs = [
+        o for o in outputs if o.get("output_type") in ("stream", "display_data")
+    ]
+
+    # Verify we have at least 3 outputs in order
+    if len(main_outputs) >= 3:
+        assert main_outputs[0]["output_type"] == "stream"
+        assert main_outputs[1]["output_type"] == "display_data"
+        assert main_outputs[2]["output_type"] == "stream"
+
+
+@pytest.mark.asyncio
+async def test_get_kernel_status(mcp_client: ClientSession):
+    """Test kernel status reporting."""
+    # Connect
+    await mcp_client.call_tool("connect_notebook", {})
+
+    # Check status before starting kernel
+    result = await mcp_client.call_tool("get_kernel_status", {})
+    data = _parse_tool_result(result)
+    assert data.get("kernel_started") is False
+
+    # Start kernel
+    await mcp_client.call_tool("start_kernel", {})
+
+    # Check status after starting
+    result = await mcp_client.call_tool("get_kernel_status", {})
+    data = _parse_tool_result(result)
+    assert data.get("kernel_started") is True
+
+
+@pytest.mark.asyncio
+async def test_delete_cell(mcp_client: ClientSession):
+    """Test cell deletion."""
+    # Connect
+    await mcp_client.call_tool("connect_notebook", {})
+
+    # Create cell
+    result = await mcp_client.call_tool("create_cell", {"source": "x = 1"})
+    data = _parse_tool_result(result)
+    cell_id = data["cell_id"]
+
+    # Delete cell
+    result = await mcp_client.call_tool("delete_cell", {"cell_id": cell_id})
+    data = _parse_tool_result(result)
+    assert data["deleted"] is True
+
+    # Verify it's gone
+    result = await mcp_client.call_tool("get_all_cells", {})
+    data = _parse_tool_result(result)
+    cell_ids = [c.get("id") for c in data] if isinstance(data, list) else []
+    assert cell_id not in cell_ids

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "mcp", specifier = ">=1.26.0" },
-    { name = "runtimed", specifier = "==0.1.5a202603050550" },
+    { name = "runtimed", specifier = ">=0.1.5a202603050742" },
 ]
 
 [package.metadata.requires-dev]
@@ -810,15 +810,16 @@ wheels = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.5a202603050550"
+version = "0.1.5a202603050742"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "mcp" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/cc/4b23706b2ad2a3c688e92130b478ade01a602e6b8a847fe28613a7ab245b/runtimed-0.1.5a202603050550-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:9f017a3ce2484231ef081dcbfaf7448bd2730063f9e4c621e74f6e7d85d911f5", size = 1394327, upload-time = "2026-03-05T06:07:17.442Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/cc/d000224f5ccf2ff6304d6919b23daca905325e69ddce6c637b0227b49abe/runtimed-0.1.5a202603050550-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:d5bedf40b4b34cbc0493677d371ff0ea09f1b41fd567bf7fe79b399e1bb3cf41", size = 3899954, upload-time = "2026-03-05T06:07:16.034Z" },
+    { url = "https://files.pythonhosted.org/packages/88/52/b94aa9b49ad1a592f55f554e5abe609d77f3553c25a4a65fac1b76010d56/runtimed-0.1.5a202603050742-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d3de42ffc91280495a3f81bb5aaa6ca5f7579e5c0b9249ebbfb5d94a420658e7", size = 1394519, upload-time = "2026-03-05T07:56:02.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/36/ee98e93cd0e34441264040e29a1295f7e35cd650af6694ce9acbb14d209e/runtimed-0.1.5a202603050742-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:e0d2b4d06c35a9da5a4a1d4f6412816e6794b457806710f97e82a0b0536d05c7", size = 3900145, upload-time = "2026-03-05T07:55:59.932Z" },
+    { url = "https://files.pythonhosted.org/packages/02/96/45c7c4991580f21c76c10e7356b1d31aba7555d4230c6c2f342670b36ffd/runtimed-0.1.5a202603050742-cp39-abi3-win_amd64.whl", hash = "sha256:280b71b226168eea424d4146ca29c47f6812a9d2062789359e5abb5908677dd1", size = 1392473, upload-time = "2026-03-05T07:56:01.452Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "nteract"
-version = "0.0.6"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -355,6 +355,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "anyio" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -365,11 +366,12 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "mcp", specifier = ">=1.26.0" },
-    { name = "runtimed", specifier = ">=0.1.5a202603042356" },
+    { name = "runtimed", specifier = "==0.1.5a202603050550" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "anyio", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "ruff", specifier = ">=0.9" },
@@ -808,16 +810,15 @@ wheels = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.5a202603042356"
+version = "0.1.5a202603050550"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "mcp" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/58/b44f6e8013201a749075f06bc8f920e19c696c362da4c08b7343ea6cec84/runtimed-0.1.5a202603042356-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:b3ffb0386b61ce8c481e67e56af082d9895e2952bcf2d566fda9e6b61f0271ca", size = 1356889, upload-time = "2026-03-05T00:27:37.407Z" },
-    { url = "https://files.pythonhosted.org/packages/86/45/7a0a50d536593fd3232fbffab743eb2fb34eb31e9b86f21aa3c279d9bd61/runtimed-0.1.5a202603042356-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:93735a24a4212caf1e31f2ab51734f7c54a310f023ae55a34a6cdf8db7cd7027", size = 3856709, upload-time = "2026-03-05T00:27:39.182Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/10/e98e872387ca8624d3c4d10685791872056fe3d2d10a7149c99429b5c344/runtimed-0.1.5a202603042356-cp39-abi3-win_amd64.whl", hash = "sha256:4f7ff2bfa7427de6d162379bedae052e384d5981c660a6a669261b62acfd49ce", size = 1354232, upload-time = "2026-03-05T00:27:40.955Z" },
+    { url = "https://files.pythonhosted.org/packages/62/cc/4b23706b2ad2a3c688e92130b478ade01a602e6b8a847fe28613a7ab245b/runtimed-0.1.5a202603050550-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:9f017a3ce2484231ef081dcbfaf7448bd2730063f9e4c621e74f6e7d85d911f5", size = 1394327, upload-time = "2026-03-05T06:07:17.442Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cc/d000224f5ccf2ff6304d6919b23daca905325e69ddce6c637b0227b49abe/runtimed-0.1.5a202603050550-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:d5bedf40b4b34cbc0493677d371ff0ea09f1b41fd567bf7fe79b399e1bb3cf41", size = 3899954, upload-time = "2026-03-05T06:07:16.034Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "nteract"
-version = "0.1.0"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Implements a wholesale API rethink to better serve AI agents:

- **Streaming execution**: Use `stream_execute()` from runtimed PR #528 for real-time event streaming instead of all-or-nothing execution
- **Ordered outputs**: Replace separate stdout/stderr/outputs/error fields with single ordered `outputs` list that preserves interleaving
- **Partial results**: Return what we have after timeout (default 5s), `complete: false` means agent can poll `get_cell()` for more
- **Token streaming**: Add `append_source` tool for LLM token streaming via CRDT insertion
- **Removed `run_code`**: Tool removed — agents should use `create_cell(source=..., and_run=True)` for explicit control

## API Changes

**Old format** (lost interleaving, all-or-nothing):
```json
{
  "stdout": "...",
  "stderr": "...",
  "outputs": [...],
  "error": {...}
}
```

**New format** (ordered outputs, partial results):
```json
{
  "cell_id": "abc",
  "status": "running",
  "execution_count": 5,
  "outputs": [...],
  "complete": false
}
```

## Dependencies

Updated to runtimed 0.1.5a202603050550 (pinned until full build completes with both macOS/Linux wheels).

## Test Plan

- [x] All 9 integration tests passing (append_source, execution, polling, output ordering)
- [x] Tool list verified (run_code removed, append_source added)
- [x] Linters passing (ruff, ty)
- [x] Local testing with daemon

## Version

Bumped to 0.0.7