### PR TITLE
Add socket path docs for nightly and preview builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ Or manually add to your Claude configuration:
 }
 ```
 
+### Using with Nightly or Preview
+
+If you're using nteract desktop nightly or preview builds, you need to specify the socket path:
+
+**Nightly:**
+```bash
+claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-nightly/runtimed.sock" uvx --prerelease allow nteract
+```
+
+**Preview:**
+```bash
+claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-preview/runtimed.sock" uvx --prerelease allow nteract
+```
+
 ## Available Tools
 
 | Tool | Description |


### PR DESCRIPTION
Users running nteract desktop nightly or preview builds require different socket paths to connect via MCP. This adds documentation showing the correct setup commands with the required RUNTIMED_SOCKET_PATH environment variables for both nightly and preview release channels.