### PR TITLE
Bump to 0.0.8 with runtimed deadlock fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "0.0.7"
+version = "0.0.8"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.26.0",
     "httpx>=0.27.0,<1.0",
-    "runtimed>=0.1.5a202603050742",  # Requires streaming API from PR #528
+    "runtimed>=0.1.5a202603050921",  # Deadlock fix for connect() then execute()
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "nteract"
-version = "0.0.7"
+version = "0.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -366,7 +366,7 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "mcp", specifier = ">=1.26.0" },
-    { name = "runtimed", specifier = ">=0.1.5a202603050742" },
+    { name = "runtimed", specifier = ">=0.1.5a202603050921" },
 ]
 
 [package.metadata.requires-dev]
@@ -810,16 +810,16 @@ wheels = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.5a202603050742"
+version = "0.1.5a202603050921"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "mcp" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/52/b94aa9b49ad1a592f55f554e5abe609d77f3553c25a4a65fac1b76010d56/runtimed-0.1.5a202603050742-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d3de42ffc91280495a3f81bb5aaa6ca5f7579e5c0b9249ebbfb5d94a420658e7", size = 1394519, upload-time = "2026-03-05T07:56:02.453Z" },
-    { url = "https://files.pythonhosted.org/packages/89/36/ee98e93cd0e34441264040e29a1295f7e35cd650af6694ce9acbb14d209e/runtimed-0.1.5a202603050742-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:e0d2b4d06c35a9da5a4a1d4f6412816e6794b457806710f97e82a0b0536d05c7", size = 3900145, upload-time = "2026-03-05T07:55:59.932Z" },
-    { url = "https://files.pythonhosted.org/packages/02/96/45c7c4991580f21c76c10e7356b1d31aba7555d4230c6c2f342670b36ffd/runtimed-0.1.5a202603050742-cp39-abi3-win_amd64.whl", hash = "sha256:280b71b226168eea424d4146ca29c47f6812a9d2062789359e5abb5908677dd1", size = 1392473, upload-time = "2026-03-05T07:56:01.452Z" },
+    { url = "https://files.pythonhosted.org/packages/02/25/0fb13823d698c759f577fb89e3e07b91807c4cd28e2f4812264b5cee0f2d/runtimed-0.1.5a202603050921-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:844c9406761d51fadb53e9c324ae500732850aae47b9bcf224ec9e48fe87417d", size = 1395799, upload-time = "2026-03-05T09:39:33.825Z" },
+    { url = "https://files.pythonhosted.org/packages/01/54/9205b264ecd3129d6c38232e0ae153a82392cd0c2bf0c4ded214b42c6f60/runtimed-0.1.5a202603050921-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:ce9cbd15a85f36a9d74a60e40d7395155b0c34112a70f22f72e2b6f4430e38ee", size = 3901489, upload-time = "2026-03-05T09:39:31.273Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/35/15164b6fcf6344cee8ccc427cf4c702cfa3744f68867835d86590c786588/runtimed-0.1.5a202603050921-cp39-abi3-win_amd64.whl", hash = "sha256:045ada02e0b7d664ece3ae6595f1f9a7a9696370e3b7203e04cdcfa8658127fa", size = 1393195, upload-time = "2026-03-05T09:39:32.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps nteract to 0.0.8
- Updates runtimed to 0.1.5a202603050921 which fixes a deadlock when `connect()` is called before `execute_cell()`

## What was fixed

When an agent connected to an existing notebook (with a kernel already running from nteract desktop), execution would silently hang. The runtimed fix allows execution to work automatically without requiring explicit `start_kernel()` calls.

## Test plan

- [ ] Connect to a notebook that already has a kernel running
- [ ] Call `create_cell(and_run=true)` without calling `start_kernel()` first
- [ ] Execution should work immediately