### PR TITLE
Send logs to stderr

### DIFF
--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -19,6 +19,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import sys
 from typing import Any
 
 import runtimed
@@ -532,6 +533,7 @@ def main():
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stderr,
     )
     mcp.run(transport="stdio")
 


### PR DESCRIPTION
MCP servers using stdio transport communicate via stdout for JSON-RPC. Logs must go to stderr so they appear in Claude's log viewer instead of interfering with protocol communication.

This change adds `sys.stderr` as the stream for the logging configuration, ensuring logs are properly routed to stderr for visibility in the Claude Code environment.