### PR TITLE
Terminal-friendly output formatting for MCP tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.26.0",
     "httpx>=0.27.0,<1.0",
-    "runtimed>=0.1.5a202603050921",  # Deadlock fix for connect() then execute()
+    "runtimed>=0.1.5a",  # Requires deadlock fix from 0.1.5a202603050921+
 ]
 
 [project.scripts]

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -245,8 +245,34 @@ async def disconnect_notebook() -> dict[str, Any]:
     return {"disconnected": True}
 
 
+def _format_notebook_list(rooms: list[dict[str, Any]]) -> str:
+    """Format notebook rooms for terminal display."""
+    if not rooms:
+        return "No active notebooks"
+
+    lines = [f"Notebooks ({len(rooms)}):"]
+    for room in rooms:
+        notebook_id = room.get("notebook_id", "unknown")
+        peers = room.get("active_peers", 0)
+        has_kernel = room.get("has_kernel", False)
+
+        # Build kernel info
+        if has_kernel:
+            kernel_type = room.get("kernel_type", "unknown")
+            kernel_status = room.get("kernel_status", "unknown")
+            env_source = room.get("env_source", "unknown")
+            kernel_info = f"{kernel_type} ({kernel_status}) | env: {env_source}"
+        else:
+            kernel_info = "no kernel"
+
+        lines.append(f"\n• {notebook_id}")
+        lines.append(f"  {kernel_info} | peers: {peers}")
+
+    return "\n".join(lines)
+
+
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-async def list_notebooks() -> list[dict[str, Any]]:
+async def list_notebooks() -> TextContent:
     """List all active notebook rooms in the daemon.
 
     Returns:
@@ -256,7 +282,7 @@ async def list_notebooks() -> list[dict[str, Any]]:
     rooms = client.list_rooms()
     # rooms is a list of dicts with keys: notebook_id, active_peers, has_kernel,
     # kernel_type (optional), kernel_status (optional), env_source (optional)
-    return [dict(room) for room in rooms]
+    return TextContent(type="text", text=_format_notebook_list([dict(room) for room in rooms]))
 
 
 # =============================================================================

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -23,7 +23,7 @@ from typing import Any
 
 import runtimed
 from mcp.server.fastmcp import FastMCP
-from mcp.types import ToolAnnotations
+from mcp.types import TextContent, ToolAnnotations
 
 logger = logging.getLogger(__name__)
 
@@ -353,7 +353,7 @@ async def create_cell(
     index: int | None = None,
     and_run: bool = False,
     timeout_secs: float = 5.0,
-) -> str:
+) -> TextContent:
     """Create a new cell in the notebook, optionally executing it.
 
     The cell is added to the shared document and synced to all connected
@@ -381,7 +381,7 @@ async def create_cell(
     if and_run and cell_type == "code":
         return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
 
-    return f"Created cell: {cell_id}"
+    return TextContent(type="text", text=f"Created cell: {cell_id}")
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
@@ -424,7 +424,7 @@ async def append_source(cell_id: str, text: str) -> dict[str, Any]:
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-async def get_cell(cell_id: str) -> str:
+async def get_cell(cell_id: str) -> TextContent:
     """Get a cell by ID, including outputs if available.
 
     Outputs are resolved from the Automerge document, so you can see
@@ -438,13 +438,11 @@ async def get_cell(cell_id: str) -> str:
     """
     session = await _get_session()
     cell = await session.get_cell(cell_id=cell_id)
-    return _format_cell(
-        cell,
-    )
+    return TextContent(type="text", text=_format_cell(cell))
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-async def get_all_cells() -> str:
+async def get_all_cells() -> TextContent:
     """Get all cells in the current notebook, including outputs.
 
     Outputs are resolved from the Automerge document, so you can see
@@ -455,13 +453,8 @@ async def get_all_cells() -> str:
     """
     session = await _get_session()
     cells = await session.get_cells()
-    formatted = [
-        _format_cell(
-            cell,
-        )
-        for cell in cells
-    ]
-    return "\n\n".join(formatted)
+    formatted = [_format_cell(cell) for cell in cells]
+    return TextContent(type="text", text="\n\n".join(formatted))
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
@@ -490,7 +483,7 @@ async def delete_cell(cell_id: str) -> dict[str, Any]:
 async def _execute_cell_internal(
     cell_id: str,
     timeout_secs: float = 5.0,
-) -> str:
+) -> TextContent:
     """Internal execution with streaming and partial results."""
     session = await _get_session()
     events: list[Any] = []  # list[runtimed.ExecutionEvent]
@@ -507,14 +500,14 @@ async def _execute_cell_internal(
     with contextlib.suppress(asyncio.TimeoutError):
         await asyncio.wait_for(collect_events(), timeout=timeout_secs)
 
-    return _format_execution_result(cell_id, events, complete)
+    return TextContent(type="text", text=_format_execution_result(cell_id, events, complete))
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def execute_cell(
     cell_id: str,
     timeout_secs: float = 5.0,
-) -> str:
+) -> TextContent:
     """Execute a cell by ID.
 
     Returns partial results after timeout_secs if still running.

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -50,53 +50,116 @@ async def _get_session() -> runtimed.AsyncSession:
     return _session
 
 
-def _output_to_dict(output: runtimed.Output) -> dict[str, Any]:
-    """Convert an Output to a JSON-serializable dict."""
-    result: dict[str, Any] = {"output_type": output.output_type}
+def _format_output_text(output: runtimed.Output) -> str | None:
+    """Extract text representation from a single output.
 
-    if output.name is not None:
-        result["name"] = output.name
-    if output.text is not None:
-        result["text"] = output.text
-    if output.data is not None:
-        result["data"] = output.data
-    if output.ename is not None:
-        result["ename"] = output.ename
-    if output.evalue is not None:
-        result["evalue"] = output.evalue
-    if output.traceback is not None:
-        result["traceback"] = output.traceback
-    if output.execution_count is not None:
-        result["execution_count"] = output.execution_count
-
-    return result
-
-
-def _cell_to_dict(cell: runtimed.Cell) -> dict[str, Any]:
-    """Convert a Cell to a JSON-serializable dict with outputs from Automerge."""
-    return {
-        "id": cell.id,
-        "cell_type": cell.cell_type,
-        "source": cell.source,
-        "execution_count": cell.execution_count,
-        "outputs": [_output_to_dict(o) for o in cell.outputs],
-    }
-
-
-def _execution_to_dict(
-    cell_id: str,
-    events: list[Any],  # list[runtimed.ExecutionEvent] - type not exported yet
-    complete: bool,
-) -> dict[str, Any]:
-    """Convert execution events to agent-friendly format.
-
-    Returns ordered outputs preserving interleaving (stdout/display_data/etc).
-    Status reflects execution outcome:
-    - "running": execution in progress
-    - "idle": completed successfully
-    - "error": execution raised an exception or kernel error
+    Returns the best text representation, or None if no text available.
+    Priority: text/markdown > text/plain > application/json
     """
-    outputs: list[dict[str, Any]] = []
+    if output.output_type == "stream":
+        return output.text
+
+    if output.output_type == "error":
+        parts = []
+        if output.ename and output.evalue:
+            parts.append(f"{output.ename}: {output.evalue}")
+        elif output.evalue:
+            parts.append(output.evalue)
+        if output.traceback:
+            parts.append("\n".join(output.traceback))
+        return "\n".join(parts) if parts else None
+
+    if output.output_type in ("display_data", "execute_result"):
+        if output.data is None:
+            return None
+        # Priority: text/markdown > text/plain > application/json
+        if "text/markdown" in output.data:
+            return output.data["text/markdown"]
+        if "text/plain" in output.data:
+            return output.data["text/plain"]
+        if "application/json" in output.data:
+            try:
+                data = output.data["application/json"]
+                # If it's already a string, try to parse and pretty-print
+                if isinstance(data, str):
+                    return json.dumps(json.loads(data), indent=2)
+                return json.dumps(data, indent=2)
+            except (json.JSONDecodeError, TypeError):
+                return str(output.data["application/json"])
+        return None
+
+    return None
+
+
+def _format_outputs_text(outputs: list[runtimed.Output]) -> str:
+    """Convert a list of outputs to readable text.
+
+    Extracts only text-based representations (text/markdown, text/plain,
+    application/json). Ignores images, HTML, and other binary formats.
+    """
+    parts: list[str] = []
+    for output in outputs:
+        text = _format_output_text(output)
+        if text:
+            parts.append(text)
+    return "\n\n".join(parts)
+
+
+def _format_header(
+    cell_id: str,
+    status: str | None = None,
+    execution_count: int | None = None,
+) -> str:
+    """Format a cell header line for terminal display.
+
+    Example: ━━━ cell-abc12345 ✓ idle [3] ━━━
+    """
+    icons = {"idle": "✓", "error": "✗", "running": "◐"}
+
+    parts = [f"━━━ {cell_id}"]
+
+    if status:
+        icon = icons.get(status, "?")
+        parts.append(f"{icon} {status}")
+
+    if execution_count is not None:
+        parts.append(f"[{execution_count}]")
+
+    parts.append("━━━")
+    return " ".join(parts)
+
+
+def _format_cell(cell: runtimed.Cell) -> str:
+    """Format a cell for terminal display (includes source).
+
+    Used by get_cell to show full cell state.
+    """
+    header = _format_header(cell.id, execution_count=cell.execution_count)
+    output_text = _format_outputs_text(cell.outputs)
+
+    if cell.source and output_text:
+        return f"{header}\n\n{cell.source}\n\n───────────────────\n\n{output_text}"
+    elif cell.source:
+        return f"{header}\n\n{cell.source}"
+    elif output_text:
+        return f"{header}\n\n{output_text}"
+    else:
+        return header
+
+
+def _format_execution_result(
+    cell_id: str,
+    events: list[Any],  # list[runtimed.ExecutionEvent]
+    complete: bool,
+) -> str:
+    """Format execution result for terminal display.
+
+    Status reflects execution outcome:
+    - "running": execution in progress (complete=false)
+    - "idle": completed successfully
+    - "error": execution raised an exception
+    """
+    outputs: list[runtimed.Output] = []
     execution_count: int | None = None
     status = "running"
     has_error_output = False
@@ -105,25 +168,23 @@ def _execution_to_dict(
         if event.event_type == "execution_started":
             execution_count = event.execution_count
         elif event.event_type == "output":
-            output_dict = _output_to_dict(event.output)
-            outputs.append(output_dict)
-            # Check for error output from user code exceptions (e.g., 1/0)
-            if output_dict.get("output_type") == "error":
+            outputs.append(event.output)
+            if event.output.output_type == "error":
                 has_error_output = True
         elif event.event_type == "done":
-            # Set status based on whether any error output was produced
             status = "error" if has_error_output else "idle"
         elif event.event_type == "error":
-            # Transport/kernel-level error
             status = "error"
 
-    return {
-        "cell_id": cell_id,
-        "status": status,
-        "execution_count": execution_count,
-        "outputs": outputs,
-        "complete": complete,
-    }
+    header = _format_header(cell_id, status=status, execution_count=execution_count)
+    output_text = _format_outputs_text(outputs)
+
+    if output_text:
+        return f"{header}\n\n{output_text}"
+    elif not complete:
+        return f"{header}\n\n(execution in progress...)"
+    else:
+        return header
 
 
 # =============================================================================
@@ -292,7 +353,7 @@ async def create_cell(
     index: int | None = None,
     and_run: bool = False,
     timeout_secs: float = 5.0,
-) -> dict[str, Any]:
+) -> str:
     """Create a new cell in the notebook, optionally executing it.
 
     The cell is added to the shared document and synced to all connected
@@ -307,8 +368,8 @@ async def create_cell(
             takes longer, returns partial results with complete=False.
 
     Returns:
-        Cell info including id. If and_run=True, includes outputs and status.
-        Check 'complete' field to know if execution finished.
+        If and_run=False: The cell_id.
+        If and_run=True: Cell with execution status and outputs.
     """
     session = await _get_session()
     cell_id = await session.create_cell(
@@ -317,13 +378,10 @@ async def create_cell(
         index=index,
     )
 
-    result: dict[str, Any] = {"cell_id": cell_id, "created": True}
-
     if and_run and cell_type == "code":
-        exec_result = await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
-        result.update(exec_result)
+        return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
 
-    return result
+    return f"Created cell: {cell_id}"
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
@@ -366,7 +424,7 @@ async def append_source(cell_id: str, text: str) -> dict[str, Any]:
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-async def get_cell(cell_id: str) -> dict[str, Any]:
+async def get_cell(cell_id: str) -> str:
     """Get a cell by ID, including outputs if available.
 
     Outputs are resolved from the Automerge document, so you can see
@@ -376,27 +434,34 @@ async def get_cell(cell_id: str) -> dict[str, Any]:
         cell_id: The cell ID.
 
     Returns:
-        Cell info including id, cell_type, source, execution_count,
-        and outputs if available.
+        Cell with source code and outputs.
     """
     session = await _get_session()
     cell = await session.get_cell(cell_id=cell_id)
-    return _cell_to_dict(cell)
+    return _format_cell(
+        cell,
+    )
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-async def get_all_cells() -> list[dict[str, Any]]:
+async def get_all_cells() -> str:
     """Get all cells in the current notebook, including outputs.
 
     Outputs are resolved from the Automerge document, so you can see
     outputs from cells executed by other clients.
 
     Returns:
-        List of cells with their info and outputs.
+        All cells with source code and outputs.
     """
     session = await _get_session()
     cells = await session.get_cells()
-    return [_cell_to_dict(cell) for cell in cells]
+    formatted = [
+        _format_cell(
+            cell,
+        )
+        for cell in cells
+    ]
+    return "\n\n".join(formatted)
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
@@ -425,7 +490,7 @@ async def delete_cell(cell_id: str) -> dict[str, Any]:
 async def _execute_cell_internal(
     cell_id: str,
     timeout_secs: float = 5.0,
-) -> dict[str, Any]:
+) -> str:
     """Internal execution with streaming and partial results."""
     session = await _get_session()
     events: list[Any] = []  # list[runtimed.ExecutionEvent]
@@ -442,28 +507,25 @@ async def _execute_cell_internal(
     with contextlib.suppress(asyncio.TimeoutError):
         await asyncio.wait_for(collect_events(), timeout=timeout_secs)
 
-    return _execution_to_dict(cell_id, events, complete)
+    return _format_execution_result(cell_id, events, complete)
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def execute_cell(
     cell_id: str,
     timeout_secs: float = 5.0,
-) -> dict[str, Any]:
+) -> str:
     """Execute a cell by ID.
 
     Returns partial results after timeout_secs if still running.
-    Check 'complete' field - if False, use get_cell() to poll for more outputs.
-
-    If no kernel is running, one will be started automatically.
+    If status shows "running", use get_cell() to poll for more outputs.
 
     Args:
         cell_id: The cell ID to execute.
         timeout_secs: Maximum time to wait for execution (default: 5s).
 
     Returns:
-        Execution result with ordered outputs preserving interleaving.
-        Fields: cell_id, status, execution_count, outputs, complete.
+        Cell with execution status and outputs.
     """
     return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
 
@@ -475,15 +537,21 @@ async def execute_cell(
 
 @mcp.resource("notebook://cells")
 async def resource_cells() -> str:
-    """Get all cells in the current notebook as JSON."""
+    """Get all cells in the current notebook."""
     if _session is None:
-        return json.dumps({"error": "No active session"})
+        return "Error: No active session"
 
     try:
         cells = await _session.get_cells()
-        return json.dumps([_cell_to_dict(cell) for cell in cells])
+        formatted = [
+            _format_cell(
+                cell,
+            )
+            for cell in cells
+        ]
+        return "\n\n".join(formatted)
     except Exception as e:
-        return json.dumps({"error": str(e)})
+        return f"Error: {e}"
 
 
 @mcp.resource("notebook://status")

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import re
 from typing import Any
 
 import anyio
@@ -74,14 +75,34 @@ async def mcp_client():
             await client.__aexit__(None, None, None)
 
 
-def _parse_tool_result(result: Any) -> dict[str, Any]:
-    """Parse tool result from MCP response."""
-    # Tool results come as a list of content blocks
+def _get_text(result: Any) -> str:
+    """Get text content from MCP tool result."""
     if hasattr(result, "content") and result.content:
         content = result.content[0]
         if hasattr(content, "text"):
-            return json.loads(content.text)
+            return content.text
+    return ""
+
+
+def _parse_json(result: Any) -> dict[str, Any]:
+    """Parse JSON from MCP tool result (for tools that return JSON)."""
+    text = _get_text(result)
+    if text:
+        return json.loads(text)
     return {}
+
+
+def _extract_cell_id(text: str) -> str | None:
+    """Extract cell ID from 'Created cell: {id}' or header format."""
+    # Match "Created cell: cell-uuid"
+    match = re.search(r"Created cell: (cell-[\w-]+)", text)
+    if match:
+        return match.group(1)
+    # Match header format "━━━ cell-uuid" (full ID in header)
+    match = re.search(r"━━━ (cell-[\w-]+)", text)
+    if match:
+        return match.group(1)
+    return None
 
 
 @pytest.mark.asyncio
@@ -115,25 +136,24 @@ async def test_connect_and_create_cell(mcp_client: ClientSession):
     """Connect to notebook and create a cell."""
     # Connect
     result = await mcp_client.call_tool("connect_notebook", {})
-    data = _parse_tool_result(result)
+    data = _parse_json(result)
     assert data["connected"] is True
     assert "notebook_id" in data
 
-    # Create cell
+    # Create cell (returns plain text)
     result = await mcp_client.call_tool(
         "create_cell",
         {"source": "print('hello')", "cell_type": "code"},
     )
-    data = _parse_tool_result(result)
-    assert data["created"] is True
-    assert "cell_id" in data
+    text = _get_text(result)
+    assert "Created cell:" in text
+    cell_id = _extract_cell_id(text)
+    assert cell_id is not None
 
-    # Get cell
-    cell_id = data["cell_id"]
+    # Get cell (returns formatted string with source)
     result = await mcp_client.call_tool("get_cell", {"cell_id": cell_id})
-    data = _parse_tool_result(result)
-    assert data["source"] == "print('hello')"
-    assert data["cell_type"] == "code"
+    text = _get_text(result)
+    assert "print('hello')" in text
 
 
 @pytest.mark.asyncio
@@ -144,8 +164,9 @@ async def test_append_source(mcp_client: ClientSession):
 
     # Create empty cell
     result = await mcp_client.call_tool("create_cell", {"source": ""})
-    data = _parse_tool_result(result)
-    cell_id = data["cell_id"]
+    text = _get_text(result)
+    cell_id = _extract_cell_id(text)
+    assert cell_id is not None
 
     # Stream tokens
     tokens = ["print", "(", "'hello", " ", "world", "'", ")"]
@@ -154,13 +175,13 @@ async def test_append_source(mcp_client: ClientSession):
             "append_source",
             {"cell_id": cell_id, "text": token},
         )
-        data = _parse_tool_result(result)
+        data = _parse_json(result)
         assert data["appended"] is True
 
     # Verify final source
     result = await mcp_client.call_tool("get_cell", {"cell_id": cell_id})
-    data = _parse_tool_result(result)
-    assert data["source"] == "print('hello world')"
+    text = _get_text(result)
+    assert "print('hello world')" in text
 
 
 @pytest.mark.asyncio
@@ -179,13 +200,11 @@ async def test_execute_cell_basic(mcp_client: ClientSession):
             "timeout_secs": 30.0,  # Give enough time for kernel warmup
         },
     )
-    data = _parse_tool_result(result)
+    text = _get_text(result)
 
-    assert data["created"] is True
-    assert "cell_id" in data
-    # Should have status and outputs
-    assert "status" in data
-    assert "outputs" in data
+    # Should have header with cell ID and output
+    assert "cell-" in text
+    assert "hello from kernel" in text
 
 
 @pytest.mark.asyncio
@@ -204,17 +223,11 @@ async def test_execute_cell_partial_results(mcp_client: ClientSession):
             "timeout_secs": 2.0,  # Short timeout to test partial results
         },
     )
-    data = _parse_tool_result(result)
+    text = _get_text(result)
 
-    # Should have partial output and complete=False
-    assert data.get("complete") is False
-    assert data.get("status") == "running"
-    # Should have at least the "start" output
-    outputs = data.get("outputs", [])
-    output_text = "".join(
-        o.get("text", "") for o in outputs if o.get("output_type") == "stream"
-    )
-    assert "start" in output_text
+    # Should have partial output with "start" and running status
+    assert "running" in text
+    assert "start" in text
 
 
 @pytest.mark.asyncio
@@ -233,23 +246,20 @@ async def test_poll_for_outputs(mcp_client: ClientSession):
             "timeout_secs": 0.5,  # Return before completion
         },
     )
-    data = _parse_tool_result(result)
-    cell_id = data["cell_id"]
+    text = _get_text(result)
+    cell_id = _extract_cell_id(text)
+    assert cell_id is not None
 
-    # Should be incomplete
-    assert data.get("complete") is False
+    # Should be incomplete (running status)
+    assert "running" in text
 
     # Wait and poll
     await anyio.sleep(2)
     result = await mcp_client.call_tool("get_cell", {"cell_id": cell_id})
-    data = _parse_tool_result(result)
+    text = _get_text(result)
 
     # Should now have the output
-    outputs = data.get("outputs", [])
-    output_text = "".join(
-        o.get("text", "") for o in outputs if o.get("output_type") == "stream"
-    )
-    assert "done" in output_text
+    assert "done" in text
 
 
 @pytest.mark.asyncio
@@ -275,22 +285,20 @@ print('c', flush=True)
             "timeout_secs": 30.0,
         },
     )
-    data = _parse_tool_result(result)
+    text = _get_text(result)
 
-    outputs = data.get("outputs", [])
-    # Should be: stream(a), display_data(b), stream(c) in order
-    # Filter to just the main output types
-    main_outputs = [
-        o for o in outputs if o.get("output_type") in ("stream", "display_data")
-    ]
+    # Should contain a, b, c in that order
+    assert "a" in text, "Output should contain 'a'"
+    assert "b" in text, "Output should contain 'b'"
+    assert "c" in text, "Output should contain 'c'"
 
-    # Strict assertion: must have exactly 3 outputs in the expected order
-    assert len(main_outputs) == 3, f"Expected 3 outputs, got {len(main_outputs)}: {main_outputs}"
-    assert main_outputs[0]["output_type"] == "stream", "First output should be stream"
-    assert "a" in main_outputs[0].get("text", ""), "First output should contain 'a'"
-    assert main_outputs[1]["output_type"] == "display_data", "Second output should be display_data"
-    assert main_outputs[2]["output_type"] == "stream", "Third output should be stream"
-    assert "c" in main_outputs[2].get("text", ""), "Third output should contain 'c'"
+    # Verify ordering: a comes before b, b comes before c
+    pos_a = text.find("\na\n")  # Look for 'a' on its own line
+    pos_b = text.find("'b'")  # display('b') shows as 'b'
+    pos_c = text.find("\nc\n")  # Look for 'c' on its own line
+    assert pos_a < pos_b < pos_c, (
+        f"Outputs should be in order a, b, c. Got positions: a={pos_a}, b={pos_b}, c={pos_c}"
+    )
 
 
 @pytest.mark.asyncio
@@ -301,7 +309,7 @@ async def test_get_kernel_status(mcp_client: ClientSession):
 
     # Check status before starting kernel
     result = await mcp_client.call_tool("get_kernel_status", {})
-    data = _parse_tool_result(result)
+    data = _parse_json(result)
     assert data.get("kernel_started") is False
 
     # Start kernel
@@ -309,7 +317,7 @@ async def test_get_kernel_status(mcp_client: ClientSession):
 
     # Check status after starting
     result = await mcp_client.call_tool("get_kernel_status", {})
-    data = _parse_tool_result(result)
+    data = _parse_json(result)
     assert data.get("kernel_started") is True
 
 
@@ -321,16 +329,17 @@ async def test_delete_cell(mcp_client: ClientSession):
 
     # Create cell
     result = await mcp_client.call_tool("create_cell", {"source": "x = 1"})
-    data = _parse_tool_result(result)
-    cell_id = data["cell_id"]
+    text = _get_text(result)
+    cell_id = _extract_cell_id(text)
+    assert cell_id is not None
 
     # Delete cell
     result = await mcp_client.call_tool("delete_cell", {"cell_id": cell_id})
-    data = _parse_tool_result(result)
+    data = _parse_json(result)
     assert data["deleted"] is True
 
-    # Verify it's gone
+    # Verify it's gone - get_all_cells returns formatted string
     result = await mcp_client.call_tool("get_all_cells", {})
-    data = _parse_tool_result(result)
-    cell_ids = [c.get("id") for c in data] if isinstance(data, list) else []
-    assert cell_id not in cell_ids
+    text = _get_text(result)
+    # The full cell_id shouldn't appear (we only show first 8 chars in header)
+    assert cell_id not in text

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "mcp", specifier = ">=1.26.0" },
-    { name = "runtimed", specifier = ">=0.1.5a202603050921" },
+    { name = "runtimed", specifier = ">=0.1.5a0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Replace verbose JSON output with readable terminal format optimized for AI agents in terminal UIs like Claude Code.

## Changes

- **Cell headers**: `━━━ cell-id ✓ idle [3] ━━━` with status icons (✓ idle, ✗ error, ◐ running)
- **Source/output separation**: `get_cell` shows source with `───` separator before outputs
- **Text extraction**: Only extract text-based representations (text/markdown > text/plain > application/json)
- **Notebook listing**: `list_notebooks` returns formatted list instead of JSON
- **TextContent returns**: Tools return `TextContent` for clean output without JSON wrapping

## Example Output

```
━━━ cell-abc123 ✓ idle [3] ━━━

hello world
```

```
Notebooks (1):

• /path/to/notebook.ipynb
  python (idle) | env: uv:inline | peers: 2
```