### PR TITLE
Add dependency management and notebook lifecycle MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,16 +91,28 @@ claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-ni
 
 | Tool | Description |
 |------|-------------|
-| `connect_notebook` | Connect to a notebook (new or existing) |
+| `connect_notebook` | Connect to a notebook by ID |
+| `open_notebook` | Open an existing .ipynb file |
+| `create_notebook` | Create a new notebook |
 | `create_cell` | Add a cell to the notebook (use `and_run=True` to execute) |
 | `execute_cell` | Run a specific cell (returns partial results after timeout) |
+| `run_all_cells` | Queue all code cells for execution |
 | `append_source` | Stream tokens into a cell (ideal for LLM output) |
 | `get_cell` | Get a cell by ID with outputs |
 | `get_all_cells` | View all cells in the notebook |
 | `set_cell_source` | Update a cell's source code |
+| `clear_outputs` | Clear a cell's outputs |
 | `delete_cell` | Remove a cell from the notebook |
 | `start_kernel` | Start a Python kernel |
+| `restart_kernel` | Restart kernel with updated dependencies |
 | `get_kernel_status` | Check kernel state |
+| `get_queue_state` | See what's executing and what's queued |
+| `complete_code` | Get code completions from the kernel |
+| `get_history` | Search kernel execution history |
+| `add_dependency` | Add a Python package dependency |
+| `remove_dependency` | Remove a dependency |
+| `get_dependencies` | List current dependencies |
+| `sync_environment` | Hot-install new deps without restart |
 
 ## Architecture
 

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -417,6 +417,66 @@ async def disconnect_notebook() -> dict[str, Any]:
     return {"disconnected": True}
 
 
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+async def open_notebook(path: str) -> dict[str, Any]:
+    """Open an existing notebook file.
+
+    Connects to the notebook via the daemon. If already connected to
+    a different notebook, disconnects first.
+
+    Args:
+        path: Path to the .ipynb file.
+
+    Returns:
+        Connection info including notebook_id and trust status.
+    """
+    global _session
+
+    if _session is not None:
+        with contextlib.suppress(Exception):
+            await _session.close()
+
+    _session = await runtimed.AsyncSession.open_notebook(path)
+    info = await _session.connection_info()
+    return {
+        "notebook_id": _session.notebook_id,
+        "path": path,
+        "cell_count": info.cell_count if info else 0,
+        "needs_trust_approval": info.needs_trust_approval if info else False,
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+async def create_notebook(
+    runtime: str = "python",
+    working_dir: str | None = None,
+) -> dict[str, Any]:
+    """Create a new notebook.
+
+    Creates an empty notebook with one code cell via the daemon.
+
+    Args:
+        runtime: Kernel runtime type ("python" or "deno").
+        working_dir: Optional working directory for project detection.
+
+    Returns:
+        Connection info for the new notebook.
+    """
+    global _session
+
+    if _session is not None:
+        with contextlib.suppress(Exception):
+            await _session.close()
+
+    _session = await runtimed.AsyncSession.create_notebook(runtime=runtime, working_dir=working_dir)
+    info = await _session.connection_info()
+    return {
+        "notebook_id": _session.notebook_id,
+        "runtime": runtime,
+        "cell_count": info.cell_count if info else 1,
+    }
+
+
 def _format_notebook_list(rooms: list[dict[str, Any]]) -> str:
     """Format notebook rooms for terminal display."""
     if not rooms:
@@ -521,6 +581,22 @@ async def interrupt_kernel() -> dict[str, Any]:
     return {"interrupted": True}
 
 
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def restart_kernel() -> dict[str, Any]:
+    """Restart the kernel with updated dependencies.
+
+    Clears all kernel state and reloads dependencies from notebook metadata.
+    Use this after adding/removing dependencies when sync_environment()
+    isn't sufficient.
+
+    Returns:
+        Confirmation of restart with the new env_source.
+    """
+    session = await _get_session()
+    await session.restart_kernel(wait_for_ready=True)
+    return {"restarted": True, "env_source": await session.env_source()}
+
+
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_kernel_status() -> dict[str, Any]:
     """Get the kernel status for the current session.
@@ -534,6 +610,144 @@ async def get_kernel_status() -> dict[str, Any]:
         "connected": await session.is_connected(),
         "kernel_started": await session.kernel_started(),
         "env_source": await session.env_source(),
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def complete_code(code: str, cursor_pos: int) -> dict[str, Any]:
+    """Get code completions from the kernel.
+
+    Uses the kernel's introspection to provide context-aware completions.
+    Requires a running kernel.
+
+    Args:
+        code: The code to complete.
+        cursor_pos: Cursor position in the code (0-indexed byte offset).
+
+    Returns:
+        Completions including cursor_start, cursor_end, and items list.
+    """
+    session = await _get_session()
+    result = await session.complete(code, cursor_pos)
+    return {
+        "cursor_start": result.cursor_start,
+        "cursor_end": result.cursor_end,
+        "items": [
+            {"label": item.label, "kind": item.kind, "detail": item.detail} for item in result.items
+        ],
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_queue_state() -> dict[str, Any]:
+    """Get the current execution queue state.
+
+    Shows which cell is currently executing and which cells are queued.
+
+    Returns:
+        executing: Cell ID currently running (or null if idle).
+        queued: List of cell IDs waiting to run.
+    """
+    session = await _get_session()
+    state = await session.get_queue_state()
+    return {"executing": state.executing, "queued": state.queued}
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_history(
+    pattern: str | None = None,
+    n: int = 100,
+) -> dict[str, Any]:
+    """Search kernel execution history.
+
+    Returns previously executed code from this kernel session.
+
+    Args:
+        pattern: Optional glob pattern to filter results (e.g., "*import*").
+        n: Maximum entries to return (default 100).
+
+    Returns:
+        entries: List of history entries with session, line, and source.
+    """
+    session = await _get_session()
+    entries = await session.get_history(pattern=pattern, n=n, unique=True)
+    return {
+        "entries": [{"session": e.session, "line": e.line, "source": e.source} for e in entries]
+    }
+
+
+# =============================================================================
+# Dependency Management Tools
+# =============================================================================
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def add_dependency(package: str) -> dict[str, Any]:
+    """Add a Python package dependency to the notebook.
+
+    The package is added to the notebook's inline dependency metadata.
+    Use sync_environment() to install without restart, or restart_kernel()
+    for a clean environment with the new dependency.
+
+    Args:
+        package: PEP 508 dependency specifier (e.g., "pandas>=2.0", "requests").
+
+    Returns:
+        Updated list of dependencies.
+    """
+    session = await _get_session()
+    deps = await session.add_uv_dependency(package)
+    return {"dependencies": deps, "added": package}
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def remove_dependency(package: str) -> dict[str, Any]:
+    """Remove a dependency from the notebook.
+
+    Requires kernel restart to take effect.
+
+    Args:
+        package: Exact dependency string to remove.
+
+    Returns:
+        Updated list of dependencies.
+    """
+    session = await _get_session()
+    deps = await session.remove_uv_dependency(package)
+    return {"dependencies": deps, "removed": package}
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_dependencies() -> dict[str, Any]:
+    """Get the notebook's current dependencies.
+
+    Returns:
+        List of PEP 508 dependency specifiers.
+    """
+    session = await _get_session()
+    deps = await session.get_uv_dependencies()
+    return {"dependencies": deps}
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def sync_environment() -> dict[str, Any]:
+    """Hot-install new dependencies without restarting the kernel.
+
+    Only works for UV dependencies and only for additions.
+    If removals are needed or sync fails, use restart_kernel() instead.
+
+    Returns:
+        success: Whether sync completed.
+        synced_packages: Packages that were installed (if success).
+        needs_restart: If true, must restart kernel instead.
+    """
+    session = await _get_session()
+    result = await session.sync_environment()
+    return {
+        "success": result.success,
+        "synced_packages": result.synced_packages,
+        "error": result.error,
+        "needs_restart": result.needs_restart,
     }
 
 
@@ -673,6 +887,24 @@ async def delete_cell(cell_id: str) -> dict[str, Any]:
     return {"cell_id": cell_id, "deleted": True}
 
 
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def clear_outputs(cell_id: str) -> dict[str, Any]:
+    """Clear a cell's outputs.
+
+    Removes all outputs from the cell. Useful before re-running a cell
+    to get a clean slate.
+
+    Args:
+        cell_id: The cell ID to clear outputs from.
+
+    Returns:
+        Confirmation of clearing.
+    """
+    session = await _get_session()
+    await session.clear_outputs(cell_id)
+    return {"cell_id": cell_id, "cleared": True}
+
+
 # =============================================================================
 # Execution Tools
 # =============================================================================
@@ -719,6 +951,21 @@ async def execute_cell(
         Cell with execution status and outputs (images returned as ImageContent).
     """
     return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def run_all_cells() -> dict[str, Any]:
+    """Queue all code cells for execution.
+
+    Queues all code cells in document order. Does not wait for completion.
+    Use get_queue_state() to monitor progress or get_all_cells() to see results.
+
+    Returns:
+        count: Number of cells queued for execution.
+    """
+    session = await _get_session()
+    count = await session.run_all_cells()
+    return {"status": "queued", "count": count}
 
 
 # =============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -810,16 +810,12 @@ wheels = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.5a202603062132"
+version = "0.1.5a202603081823"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-    { name = "mcp" },
-]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/98/07c16eb199713a0604b40702b665f770db9cc92590e81aa0108a83584819/runtimed-0.1.5a202603062132-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:a1c435ac06f12423e62ddbad512e9a4ee8795668b6eacca9ca9f9f432a8f6e87", size = 1404969, upload-time = "2026-03-06T21:46:29.377Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/bd/c705a0131bfcaac348c436c8a9f143caf462b160f02a90de2c82bf4eb760/runtimed-0.1.5a202603062132-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:0d3dedb3b583d6e50bfabd346a658f2917acea114299ab450ca93b5b8bbcc27e", size = 3909247, upload-time = "2026-03-06T21:46:30.628Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/02/503fc663a19bdef572fd91305266f5cec8f9ca629bd97f38d8697cc9b548/runtimed-0.1.5a202603062132-cp39-abi3-win_amd64.whl", hash = "sha256:cdcf0def0863ac99e0eca93a3f05e31664a07e0cb2501dd0cb6cedda5ba23081", size = 1400247, upload-time = "2026-03-06T21:46:32.003Z" },
+    { url = "https://files.pythonhosted.org/packages/06/4e/49e7e985f085b6d40bd2004af59514baa1c586f58ffcd4f05aa01ccb93a6/runtimed-0.1.5a202603081823-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:92ede9a5dba99cf9ff008267b6183085bce3212d1076655f8643b55efad459b0", size = 1504363, upload-time = "2026-03-08T18:44:08.928Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ad/04dedf6807ef5c28aadd89a647b41bb920e4352f54b50b2839074ba9db6f/runtimed-0.1.5a202603081823-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:f9ab311d25b9013118ddf2c9b68d145399475078b01ba6c4be013e4b87760c9c", size = 4025201, upload-time = "2026-03-08T18:44:11.853Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/13/ca410b745edd2612466ebd52cf07066113ade3399c66ee36dd9f155e324c/runtimed-0.1.5a202603081823-cp39-abi3-win_amd64.whl", hash = "sha256:0fe2383a9fe6b36852619f6b1165a3180fbecb0545dd1a91e01636a2d8af3d6b", size = 1498209, upload-time = "2026-03-08T18:44:10.341Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Upgrade runtimed to 0.1.5a202603081823 and expose new APIs as MCP tools.

## New tools

**Notebook lifecycle:**
- `open_notebook` - Open existing .ipynb files
- `create_notebook` - Create new notebooks

**Dependency management:**
- `add_dependency` - Add UV package dependency
- `remove_dependency` - Remove dependency  
- `get_dependencies` - List current dependencies
- `sync_environment` - Hot-install deps without restart
- `restart_kernel` - Restart kernel with updated deps

**Kernel introspection (from previous commit):**
- `complete_code` - Code completions from kernel
- `get_queue_state` - Execution queue status
- `get_history` - Kernel execution history
- `clear_outputs` - Clear cell outputs
- `run_all_cells` - Execute all cells