### PR TITLE
Add save_notebook and smart package manager detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-ni
 | `connect_notebook` | Connect to a notebook by ID |
 | `open_notebook` | Open an existing .ipynb file |
 | `create_notebook` | Create a new notebook |
+| `save_notebook` | Save notebook to disk as .ipynb file |
 | `create_cell` | Add a cell to the notebook (use `and_run=True` to execute) |
 | `execute_cell` | Run a specific cell (returns partial results after timeout) |
 | `run_all_cells` | Queue all code cells for execution |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "0.0.9"
+version = "0.10.0"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -477,6 +477,23 @@ async def create_notebook(
     }
 
 
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+async def save_notebook(path: str | None = None) -> dict[str, Any]:
+    """Save the notebook to disk as a .ipynb file.
+
+    Persists the current notebook state including cells, outputs, and metadata.
+
+    Args:
+        path: File path to save to. If None, uses the notebook's original path.
+
+    Returns:
+        The absolute path where the file was saved.
+    """
+    session = await _get_session()
+    saved_path = await session.save(path)
+    return {"path": saved_path}
+
+
 def _format_notebook_list(rooms: list[dict[str, Any]]) -> str:
     """Format notebook rooms for terminal display."""
     if not rooms:
@@ -681,52 +698,85 @@ async def get_history(
 # =============================================================================
 
 
+async def _get_package_manager(session: runtimed.AsyncSession) -> str:
+    """Detect which package manager the notebook is using.
+
+    Based on env_source:
+    - "uv:inline" or "uv:prewarmed" → "uv"
+    - "conda:inline" or "conda:prewarmed" → "conda"
+    - Default to "uv" if unknown or no kernel running
+    """
+    env = await session.env_source()
+    if env and env.startswith("conda:"):
+        return "conda"
+    return "uv"
+
+
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def add_dependency(package: str) -> dict[str, Any]:
     """Add a Python package dependency to the notebook.
 
-    The package is added to the notebook's inline dependency metadata.
+    Automatically uses the notebook's configured package manager (UV or Conda)
+    based on env_source. The package is added to the notebook's inline
+    dependency metadata.
+
     Use sync_environment() to install without restart, or restart_kernel()
     for a clean environment with the new dependency.
 
     Args:
-        package: PEP 508 dependency specifier (e.g., "pandas>=2.0", "requests").
+        package: Package specifier (e.g., "pandas>=2.0", "requests").
 
     Returns:
-        Updated list of dependencies.
+        Updated list of dependencies and which package manager was used.
     """
     session = await _get_session()
-    deps = await session.add_uv_dependency(package)
-    return {"dependencies": deps, "added": package}
+    pm = await _get_package_manager(session)
+    if pm == "conda":
+        deps = await session.add_conda_dependency(package)
+    else:
+        deps = await session.add_uv_dependency(package)
+    return {"dependencies": deps, "added": package, "package_manager": pm}
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def remove_dependency(package: str) -> dict[str, Any]:
     """Remove a dependency from the notebook.
 
-    Requires kernel restart to take effect.
+    Automatically uses the notebook's configured package manager (UV or Conda)
+    based on env_source. Requires kernel restart to take effect.
 
     Args:
         package: Exact dependency string to remove.
 
     Returns:
-        Updated list of dependencies.
+        Updated list of dependencies and which package manager was used.
     """
     session = await _get_session()
-    deps = await session.remove_uv_dependency(package)
-    return {"dependencies": deps, "removed": package}
+    pm = await _get_package_manager(session)
+    if pm == "conda":
+        deps = await session.remove_conda_dependency(package)
+    else:
+        deps = await session.remove_uv_dependency(package)
+    return {"dependencies": deps, "removed": package, "package_manager": pm}
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_dependencies() -> dict[str, Any]:
     """Get the notebook's current dependencies.
 
+    Returns dependencies from the notebook's configured package manager
+    (UV or Conda) based on env_source.
+
     Returns:
-        List of PEP 508 dependency specifiers.
+        List of dependency specifiers and which package manager is active.
     """
     session = await _get_session()
-    deps = await session.get_uv_dependencies()
-    return {"dependencies": deps}
+    pm = await _get_package_manager(session)
+    if pm == "conda":
+        deps = await session.get_conda_dependencies()
+    else:
+        deps = await session.get_uv_dependencies()
+    return {"dependencies": deps, "package_manager": pm}
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -484,14 +484,26 @@ async def save_notebook(path: str | None = None) -> dict[str, Any]:
     Persists the current notebook state including cells, outputs, and metadata.
 
     Args:
-        path: File path to save to. If None, uses the notebook's original path.
+        path: File path to save to. Required for notebooks created with
+            create_notebook(). For notebooks opened with open_notebook(),
+            this can be omitted to save to the original location.
 
     Returns:
         The absolute path where the file was saved.
     """
     session = await _get_session()
-    saved_path = await session.save(path)
-    return {"path": saved_path}
+    try:
+        saved_path = await session.save(path)
+        return {"path": saved_path}
+    except Exception as e:
+        error_msg = str(e)
+        is_write_error = "Read-only" in error_msg or "Failed to write" in error_msg
+        if is_write_error and path is None:
+            raise RuntimeError(
+                "No path specified. For notebooks created with create_notebook(), "
+                "you must provide a path (e.g., save_notebook('/path/to/file.ipynb'))"
+            ) from e
+        raise
 
 
 def _format_notebook_list(rooms: list[dict[str, Any]]) -> str:
@@ -701,14 +713,24 @@ async def get_history(
 async def _get_package_manager(session: runtimed.AsyncSession) -> str:
     """Detect which package manager the notebook is using.
 
-    Based on env_source:
-    - "uv:inline" or "uv:prewarmed" → "uv"
-    - "conda:inline" or "conda:prewarmed" → "conda"
-    - Default to "uv" if unknown or no kernel running
+    Detection order:
+    1. If kernel is running, check env_source (most reliable)
+    2. Otherwise, check stored metadata for existing dependencies
+    3. Default to "uv" if no signal
     """
+    # First check env_source if kernel is running
     env = await session.env_source()
-    if env and env.startswith("conda:"):
+    if env:
+        if env.startswith("conda:"):
+            return "conda"
+        return "uv"
+
+    # No kernel running - check stored metadata
+    # If notebook has conda deps, it's a conda notebook
+    conda_deps = await session.get_conda_dependencies()
+    if conda_deps:
         return "conda"
+
     return "uv"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "nteract"
-version = "0.0.8"
+version = "0.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -810,12 +810,12 @@ wheels = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.5a202603081823"
+version = "0.1.5a202603090259"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/4e/49e7e985f085b6d40bd2004af59514baa1c586f58ffcd4f05aa01ccb93a6/runtimed-0.1.5a202603081823-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:92ede9a5dba99cf9ff008267b6183085bce3212d1076655f8643b55efad459b0", size = 1504363, upload-time = "2026-03-08T18:44:08.928Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ad/04dedf6807ef5c28aadd89a647b41bb920e4352f54b50b2839074ba9db6f/runtimed-0.1.5a202603081823-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:f9ab311d25b9013118ddf2c9b68d145399475078b01ba6c4be013e4b87760c9c", size = 4025201, upload-time = "2026-03-08T18:44:11.853Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/13/ca410b745edd2612466ebd52cf07066113ade3399c66ee36dd9f155e324c/runtimed-0.1.5a202603081823-cp39-abi3-win_amd64.whl", hash = "sha256:0fe2383a9fe6b36852619f6b1165a3180fbecb0545dd1a91e01636a2d8af3d6b", size = 1498209, upload-time = "2026-03-08T18:44:10.341Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e7/46dacdcd54a8050510bea33e3c4a16ae9815cb937d22168ec6860e858ac5/runtimed-0.1.5a202603090259-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c64baeae4348e8caaf56d6d9099de34f7f97a3911fb3937c5265710fe36de3d7", size = 1505207, upload-time = "2026-03-09T03:11:20.05Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0c/362cbaa8e67439923d3db135a8446e0453d6f4860452c4a89ce65d327b23/runtimed-0.1.5a202603090259-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:a4a6668cc282ecfae619b7839b21c8092c4de982f558f2b0de4215945e780412", size = 4026363, upload-time = "2026-03-09T03:11:23.136Z" },
+    { url = "https://files.pythonhosted.org/packages/33/10/58dfd3ac270e726e98f39fef68886831ce278e45f9d1173f0140b4233da3/runtimed-0.1.5a202603090259-cp39-abi3-win_amd64.whl", hash = "sha256:5c131cf27e77bcf04b23028d5bcc2d3f1f6920c213bdac6cf6e3a6c2f4356554", size = 1499619, upload-time = "2026-03-09T03:11:21.633Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `save_notebook` tool to persist notebooks to disk as .ipynb files
- Update `add_dependency`, `remove_dependency`, `get_dependencies` to auto-detect package manager (UV or Conda) based on `env_source`
- All dependency tools now return `package_manager` field so agents know which system they're working with
- Upgrade runtimed to 0.1.5a202603090259