### PR TITLE
Add move_cell MCP tool on prerelease track

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,23 +23,26 @@ jobs:
         run: |
           python - <<'PY'
           import os
+          import re
           import tomllib
-          from packaging.version import Version
 
           target = os.environ["TARGET_COMMITISH"]
           is_prerelease = os.environ["IS_PRERELEASE"].lower() == "true"
 
           with open("pyproject.toml", "rb") as f:
-            version = Version(tomllib.load(f)["project"]["version"])
+            version = tomllib.load(f)["project"]["version"]
+
+          prerelease_match = re.match(r"^(\d+)\.(\d+)\.(\d+)a\d+$", version)
+          stable_match = re.match(r"^(\d+)\.(\d+)\.(\d+)$", version)
 
           if target == "main":
             assert is_prerelease, "Releases from main must be GitHub prereleases"
-            assert version.is_prerelease, "Versions on main must be prereleases"
-            assert version.major >= 2, "Versions on main must be on the 2.x prerelease line"
+            assert prerelease_match, "Versions on main must be prereleases like 2.0.1a<timestamp>"
+            assert int(prerelease_match.group(1)) >= 2, "Versions on main must be on the 2.x prerelease line"
           elif target == "release/1.9.x":
             assert not is_prerelease, "Releases from release/1.9.x must be stable"
-            assert not version.is_prerelease, "release/1.9.x must publish stable versions"
-            assert version.major == 1 and version.minor == 9, "release/1.9.x must stay on 1.9.x"
+            assert stable_match, "release/1.9.x must publish stable versions like 1.9.x"
+            assert stable_match.group(1) == "1" and stable_match.group(2) == "9", "release/1.9.x must stay on 1.9.x"
           else:
             raise AssertionError(
               f"Unsupported release target '{target}'. Use main for prereleases or release/1.9.x for stable releases."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,36 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      - name: Validate release track
+        env:
+          TARGET_COMMITISH: ${{ github.event.release.target_commitish }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+          from packaging.version import Version
+
+          target = os.environ["TARGET_COMMITISH"]
+          is_prerelease = os.environ["IS_PRERELEASE"].lower() == "true"
+
+          with open("pyproject.toml", "rb") as f:
+            version = Version(tomllib.load(f)["project"]["version"])
+
+          if target == "main":
+            assert is_prerelease, "Releases from main must be GitHub prereleases"
+            assert version.is_prerelease, "Versions on main must be prereleases"
+            assert version.major >= 2, "Versions on main must be on the 2.x prerelease line"
+          elif target == "release/1.9.x":
+            assert not is_prerelease, "Releases from release/1.9.x must be stable"
+            assert not version.is_prerelease, "release/1.9.x must publish stable versions"
+            assert version.major == 1 and version.minor == 9, "release/1.9.x must stay on 1.9.x"
+          else:
+            raise AssertionError(
+              f"Unsupported release target '{target}'. Use main for prereleases or release/1.9.x for stable releases."
+            )
+          PY
+
       - name: Build package
         run: uv build
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,14 @@ We're in the prelimiary stages of hooking up the realtime system from nteract/de
 #### Claude Code
 
 ```bash
-# Add to Claude Code
+# Stable desktop 1.4.x / stable MCP
 claude mcp add nteract -- uvx nteract
+```
+
+For desktop nightly / the upcoming 2.x transition, use the prerelease MCP package and nightly socket:
+
+```bash
+claude mcp add nteract-nightly -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-nightly/runtimed.sock" uvx --prerelease allow nteract
 ```
 
 That's it. Now Claude can execute Python code, create visualizations, and work with your data.
@@ -54,13 +60,21 @@ You can open the same notebook in the [nteract desktop app](https://github.com/n
 
 ## Installation
 
+Stable line for desktop `1.4.x`:
+
 ```bash
 uvx nteract
 ```
 
+Prerelease line for desktop nightly / 2.x transition:
+
+```bash
+uvx --prerelease allow nteract
+```
+
 ## Claude Code Setup
 
-Add nteract as an MCP server:
+Add stable `nteract` as an MCP server:
 
 ```bash
 claude mcp add nteract -- uvx nteract
@@ -81,11 +95,16 @@ Or manually add to your Claude configuration:
 
 ### Using with Nightly
 
-If you're using nteract desktop nightly builds, point at the nightly socket:
+If you're using nteract desktop nightly builds, point at the nightly socket and allow prereleases:
 
 ```bash
 claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-nightly/runtimed.sock" uvx --prerelease allow nteract
 ```
+
+### Release Tracks
+
+- `main` publishes prerelease `nteract` builds for the 2.x transition and tracks `runtimed 2.x` prereleases.
+- `release/1.9.x` is the stable maintenance line for desktop `1.4.x` and stays on `runtimed 1.9.0`.
 
 ## Available Tools
 
@@ -102,6 +121,7 @@ claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-ni
 | `get_cell` | Get a cell by ID with outputs |
 | `get_all_cells` | View all cells in the notebook |
 | `set_cell_source` | Update a cell's source code |
+| `move_cell` | Reorder a cell within the notebook |
 | `clear_outputs` | Clear a cell's outputs |
 | `delete_cell` | Remove a cell from the notebook |
 | `start_kernel` | Start a Python kernel |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "1.9.1"
+version = "1.9.2"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.26.0",
     "httpx>=0.27.0,<1.0",
-    "runtimed>=1.9.0,<2.0",
+    "runtimed>=2.0.1a202603110913,<3.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "1.9.2"
+version = "2.0.1a202603110913"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -968,6 +968,29 @@ async def delete_cell(cell_id: str) -> dict[str, Any]:
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def move_cell(cell_id: str, after_cell_id: str | None = None) -> dict[str, Any]:
+    """Move a cell to a new position in the notebook.
+
+    Reorders the shared document and syncs the change to all connected clients.
+
+    Args:
+        cell_id: The cell to move.
+        after_cell_id: Move after this cell. Use None to move to the start.
+
+    Returns:
+        Confirmation of the move, including the new internal position token.
+    """
+    session = await _get_session()
+    new_position = await session.move_cell(cell_id=cell_id, after_cell_id=after_cell_id)
+    return {
+        "cell_id": cell_id,
+        "after_cell_id": after_cell_id,
+        "new_position": new_position,
+        "moved": True,
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def clear_outputs(cell_id: str) -> dict[str, Any]:
     """Clear a cell's outputs.
 
@@ -1009,6 +1032,19 @@ async def _execute_cell_internal(
 
     with contextlib.suppress(asyncio.TimeoutError):
         await asyncio.wait_for(collect_events(), timeout=timeout_secs)
+
+    if complete:
+        # Prefer the synced document as the final source of truth once execution
+        # finishes. This is more robust across runtimed output transport changes.
+        session = await _get_session()
+        with contextlib.suppress(Exception):
+            cell = await session.get_cell(cell_id=cell_id)
+            has_error_output = any(output.output_type == "error" for output in cell.outputs)
+            status = "error" if has_error_output else "idle"
+            header = _format_header(cell.id, status=status, execution_count=cell.execution_count)
+            items: list[ContentItem] = [TextContent(type="text", text=header)]
+            items.extend(_outputs_to_content(cell.outputs))
+            return items
 
     return _execution_result_to_content(cell_id, events, complete)
 

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -131,6 +131,7 @@ async def test_list_tools(mcp_client: ClientSession):
     assert "get_cell" in tool_names
     assert "get_all_cells" in tool_names
     assert "delete_cell" in tool_names
+    assert "move_cell" in tool_names
     assert "execute_cell" in tool_names
 
     # run_code should be removed
@@ -349,3 +350,47 @@ async def test_delete_cell(mcp_client: ClientSession):
     text = _get_text(result)
     # The full cell_id shouldn't appear (we only show first 8 chars in header)
     assert cell_id not in text
+
+
+@pytest.mark.asyncio
+async def test_move_cell(mcp_client: ClientSession):
+    """Test cell reordering."""
+    await mcp_client.call_tool("connect_notebook", {})
+
+    result = await mcp_client.call_tool("create_cell", {"source": "first"})
+    first_id = _extract_cell_id(_get_text(result))
+    assert first_id is not None
+
+    result = await mcp_client.call_tool("create_cell", {"source": "second"})
+    second_id = _extract_cell_id(_get_text(result))
+    assert second_id is not None
+
+    result = await mcp_client.call_tool("create_cell", {"source": "third"})
+    third_id = _extract_cell_id(_get_text(result))
+    assert third_id is not None
+
+    result = await mcp_client.call_tool(
+        "move_cell",
+        {"cell_id": third_id, "after_cell_id": first_id},
+    )
+    data = _parse_json(result)
+    assert data["moved"] is True
+    assert data["cell_id"] == third_id
+    assert data["after_cell_id"] == first_id
+
+    result = await mcp_client.call_tool("get_all_cells", {})
+    text = _get_text(result)
+    assert text.index("first") < text.index("third") < text.index("second")
+
+    result = await mcp_client.call_tool(
+        "move_cell",
+        {"cell_id": second_id, "after_cell_id": None},
+    )
+    data = _parse_json(result)
+    assert data["moved"] is True
+    assert data["cell_id"] == second_id
+    assert data["after_cell_id"] is None
+
+    result = await mcp_client.call_tool("get_all_cells", {})
+    text = _get_text(result)
+    assert text.index("second") < text.index("first") < text.index("third")

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "nteract"
-version = "1.9.1"
+version = "1.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -366,7 +366,7 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "mcp", specifier = ">=1.26.0" },
-    { name = "runtimed", specifier = ">=1.9.0,<2.0" },
+    { name = "runtimed", specifier = ">=2.0.1a202603110913,<3.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -810,12 +810,12 @@ wheels = [
 
 [[package]]
 name = "runtimed"
-version = "1.9.0"
+version = "2.0.1a202603110913"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/06/bb06ce9f92735f57467af52c0bdd3495e31a58296e62086dfcaeae306f00/runtimed-1.9.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7ec769f2c9c9cb9d7403eae8cd0a8598cc0f5b08f4e7e512f6019ecfd2200412", size = 1540939, upload-time = "2026-03-11T05:31:34.489Z" },
-    { url = "https://files.pythonhosted.org/packages/08/50/e9139ba5cf74f64427a657a7015a29caf7ec9e4325783db17226718a1d2b/runtimed-1.9.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:df4be6575062cc52ffddf2a77b10eddfddf6f001697485c82628ffceecd88164", size = 1518345, upload-time = "2026-03-11T05:31:36.824Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/c1/2a667e651b6286e06c1cea0a6d53ee8f50e86ef38134914a384a9ac09dc0/runtimed-1.9.0-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:15e17594add4b5149c34aeaf94094c40923c37691c5d2388ffbe4925bce9d6b3", size = 4037045, upload-time = "2026-03-11T05:31:39.05Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d0/4990f851606894894574958236e1cf7d19224978ae58e166a12ae8f3f4c4/runtimed-2.0.1a202603110913-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:6f1f439d50d519199e53c05f5dbfe7a2a0087e42d90e7a88bf2e4e7f09155944", size = 1543163, upload-time = "2026-03-11T09:36:08.251Z" },
+    { url = "https://files.pythonhosted.org/packages/da/4c/45cd4dff369b8a77ea0b9e82323f36a723f6bb33bfdb30f6a5b8a14d106d/runtimed-2.0.1a202603110913-cp39-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:a1d8dfa986105e64d61efed99c2a6a2a0b06756690c31e5b06ff4b36612712c3", size = 4067528, upload-time = "2026-03-11T09:36:05.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/fe/b4f3d8b01896566548554723982d277419a0ab4e07c6266bd7ab5b8147e1/runtimed-2.0.1a202603110913-cp39-abi3-win_amd64.whl", hash = "sha256:0a85544ae943208ab6e4cc8160767a2e1def413230ec870664e92a3134a37b46", size = 1541361, upload-time = "2026-03-11T09:36:09.709Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "nteract"
-version = "1.9.2"
+version = "2.0.1a202603110913"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- add a `move_cell` MCP tool backed by `runtimed.AsyncSession.move_cell`
- keep execute tool output stable while resolving final outputs from the synced document for newer `runtimed` output transport behavior
- move `main` onto the prerelease track with `nteract 2.0.1a202603110913` and `runtimed>=2.0.1a202603110913,<3.0`
- document and validate the split between prerelease `main` and stable `release/1.9.x`

## Release Tracks
- `main`: prerelease `nteract` builds for the 2.x transition
- `release/1.9.x`: stable maintenance line for desktop `1.4.x` / `runtimed 1.9.0`

## Verification
- `uv run pytest -q tests/test_smoke.py`
- `uv run pytest -q tests/test_mcp_integration.py`
- `uv run ruff check src tests`
- `uv build`
