### PR TITLE
Add nightly flag for MCP bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ We're in the prelimiary stages of hooking up the realtime system from nteract/de
 claude mcp add nteract -- uvx nteract
 ```
 
-For desktop nightly / the upcoming 2.x transition, use the prerelease MCP package and nightly socket:
+For desktop nightly / the upcoming 2.x transition, use the prerelease MCP package and the `--nightly` shorthand:
 
 ```bash
-claude mcp add nteract-nightly -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-nightly/runtimed.sock" uvx --prerelease allow nteract
+claude mcp add nteract-nightly -- uvx --prerelease allow nteract --nightly
 ```
 
 That's it. Now Claude can execute Python code, create visualizations, and work with your data.
@@ -69,7 +69,7 @@ uvx nteract
 Prerelease line for desktop nightly / 2.x transition:
 
 ```bash
-uvx --prerelease allow nteract
+uvx --prerelease allow nteract --nightly
 ```
 
 ## Claude Code Setup
@@ -95,10 +95,10 @@ Or manually add to your Claude configuration:
 
 ### Using with Nightly
 
-If you're using nteract desktop nightly builds, point at the nightly socket and allow prereleases:
+If you're using nteract desktop nightly builds, use the nightly socket shorthand and allow prereleases:
 
 ```bash
-claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-nightly/runtimed.sock" uvx --prerelease allow nteract
+claude mcp add nteract -- uvx --prerelease allow nteract --nightly
 ```
 
 ### Release Tracks

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -32,9 +32,7 @@ from mcp.types import ImageContent, TextContent, ToolAnnotations
 
 logger = logging.getLogger(__name__)
 
-_NIGHTLY_SOCKET_PATH = (
-    Path.home() / "Library" / "Caches" / "runt-nightly" / "runtimed.sock"
-)
+_NIGHTLY_SOCKET_PATH = Path.home() / "Library" / "Caches" / "runt-nightly" / "runtimed.sock"
 
 # MCP content types for tool responses
 ContentItem = TextContent | ImageContent

--- a/src/nteract/_mcp_server.py
+++ b/src/nteract/_mcp_server.py
@@ -15,12 +15,15 @@ Requires: pip install nteract
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import contextlib
 import json
 import logging
+import os
 import re
 import sys
+from pathlib import Path
 from typing import Any
 
 import runtimed
@@ -28,6 +31,10 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import ImageContent, TextContent, ToolAnnotations
 
 logger = logging.getLogger(__name__)
+
+_NIGHTLY_SOCKET_PATH = (
+    Path.home() / "Library" / "Caches" / "runt-nightly" / "runtimed.sock"
+)
 
 # MCP content types for tool responses
 ContentItem = TextContent | ImageContent
@@ -1149,13 +1156,38 @@ async def resource_rooms() -> str:
 # =============================================================================
 
 
-def main():
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the MCP server."""
+    parser = argparse.ArgumentParser(
+        prog="nteract",
+        description="Run the nteract MCP server.",
+    )
+    parser.add_argument(
+        "--nightly",
+        action="store_true",
+        help="Use the nightly runtimed socket path.",
+    )
+    return parser.parse_args(argv)
+
+
+def _configure_runtime_environment(args: argparse.Namespace) -> None:
+    """Apply CLI-derived runtime configuration before creating daemon clients."""
+    if not args.nightly:
+        return
+
+    os.environ["RUNTIMED_SOCKET_PATH"] = str(_NIGHTLY_SOCKET_PATH)
+    logger.info("Using nightly runtimed socket at %s", _NIGHTLY_SOCKET_PATH)
+
+
+def main(argv: list[str] | None = None):
     """Run the MCP server."""
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         stream=sys.stderr,
     )
+    args = _parse_args(argv)
+    _configure_runtime_environment(args)
     mcp.run(transport="stdio")
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,5 +1,7 @@
 """Smoke tests to verify the package can be imported."""
 
+import os
+
 
 def test_import():
     """Verify the nteract package can be imported."""
@@ -13,3 +15,41 @@ def test_mcp_server_import():
     from nteract._mcp_server import mcp
 
     assert mcp.name == "nteract"
+
+
+def test_main_uses_stdio_transport(monkeypatch):
+    """Verify the entrypoint starts the MCP server over stdio."""
+    from nteract import _mcp_server
+
+    monkeypatch.delenv("RUNTIMED_SOCKET_PATH", raising=False)
+
+    called: dict[str, str] = {}
+
+    def fake_run(*, transport: str):
+        called["transport"] = transport
+
+    monkeypatch.setattr(_mcp_server.mcp, "run", fake_run)
+
+    _mcp_server.main([])
+
+    assert called == {"transport": "stdio"}
+    assert "RUNTIMED_SOCKET_PATH" not in os.environ
+
+
+def test_main_nightly_sets_socket_path(monkeypatch):
+    """Verify --nightly points runtimed at the nightly daemon socket."""
+    from nteract import _mcp_server
+
+    monkeypatch.setenv("RUNTIMED_SOCKET_PATH", "/tmp/custom.sock")
+
+    called: dict[str, str] = {}
+
+    def fake_run(*, transport: str):
+        called["transport"] = transport
+
+    monkeypatch.setattr(_mcp_server.mcp, "run", fake_run)
+
+    _mcp_server.main(["--nightly"])
+
+    assert called == {"transport": "stdio"}
+    assert os.environ["RUNTIMED_SOCKET_PATH"] == str(_mcp_server._NIGHTLY_SOCKET_PATH)


### PR DESCRIPTION
## Summary
- add a `--nightly` CLI flag to the MCP entrypoint
- map `--nightly` to the nightly runtimed socket before the server starts
- update smoke tests and README examples to use the shorthand

## Testing
- uv run pytest tests/test_smoke.py
- uv run ruff check src/nteract/_mcp_server.py tests/test_smoke.py README.md

Closes nteract/desktop#779